### PR TITLE
Added catch to robot interface

### DIFF
--- a/src/mjbots_robot_interface.cpp
+++ b/src/mjbots_robot_interface.cpp
@@ -95,7 +95,11 @@ void MjbotsRobotInterface::ProcessReply() {
   // Copy results to object so controller can use
   for (auto & joint : joints_) {
     const auto servo_reply = Get(replies_, joint.get_can_id());
-    joint.UpdateMoteus(servo_reply.position, servo_reply.velocity, servo_reply.mode);
+    if(std::isnan(servo_reply.position)){
+      std::cout<<"Missing can frame for servo: " << joint.get_can_id()<< std::endl;
+    } else{
+      joint.UpdateMoteus(servo_reply.position, servo_reply.velocity, servo_reply.mode);
+    }
   }
 }
 


### PR DESCRIPTION
Adds a check to make sure the can packet actually arrived for all servos. If a servo is missing, then the state will not get updated. This mainly serves as a temporary fix and a method to observe if the packet issues continue.