### PR TITLE
Bug in ordering of the moteus joint initialization

### DIFF
--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
   //Setup joints
   std::vector<kodlab::mjbots::JointMoteus> joints;
   joints.emplace_back(100, 4, 1, -1.3635165,    1,  1);
-  joints.emplace_back(101, 4,-1,  2.688,  5.0/3.0), 1;
+  joints.emplace_back(101, 4,-1,  2.688,  5.0/3.0,  1);
   joints.emplace_back(108, 4, 1, -0.4674585,    1,  1);
 
   // Define robot options

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -42,8 +42,8 @@ class JointMoteus: public JointBase{
             int can_bus,
             int direction = 1, 
             float zero_offset = 0,
-            float max_torque = std::numeric_limits<float>::infinity(),
             float gear_ratio = 1.0, 
+            float max_torque = std::numeric_limits<float>::infinity(),
             float pos_min = -std::numeric_limits<float>::infinity(), 
             float pos_max = std::numeric_limits<float>::infinity()
             )


### PR DESCRIPTION
Fixing the ordering of the inputs in moteus joint class