### PR TITLE
Joint smart pointers

### DIFF
--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv) {
   options.soft_start_duration = 5000;
 
   // Create control loop
-  Hopping control_loop(joints, options);
+  Hopping control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it
   control_loop.Start();

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
   options.parallelize_control_loop = true; 
 
   // Create control loop
-  Joints3DoF control_loop(joints, options);
+  Joints3DoF control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it
   control_loop.Start();

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -89,7 +89,7 @@ int main(int argc, char **argv) {
   options.realtime_params.can_cpu  = 2;
   
   // Create control loop
-  ProprioJoints control_loop(joints, options);
+  ProprioJoints control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it
   control_loop.Start();

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -39,7 +39,6 @@ class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
 };
 
 int main(int argc, char **argv) {
-
   //Setup joints
   std::vector<kodlab::mjbots::JointMoteus> joints;
   joints.emplace_back(100, 4, 1, -1.3635165,   1, 1);
@@ -54,7 +53,7 @@ int main(int argc, char **argv) {
   options.realtime_params.can_cpu  = 2;
 
   // Create control loop
-  Spin_Joint control_loop(joints, options);
+  Spin_Joint control_loop(std::move(joints), options);
   // Starts the loop, and then join it
   control_loop.Start();
   control_loop.Join();

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -131,7 +131,7 @@ MjbotsControlLoop<log_type, input_type>::MjbotsControlLoop(std::vector<kodlab::m
   }
 
   // Create robot object
-  robot_ = std::make_shared<MjbotsRobotInterface>(MjbotsRobotInterface(joints,
+  robot_ = std::make_shared<MjbotsRobotInterface>(MjbotsRobotInterface(std::move(joints),
                                                                        options_.realtime_params,
                                                                        options_.soft_start_duration));
 }

--- a/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
@@ -108,11 +108,12 @@ class MjbotsRobotInterface {
   int num_servos_;                         /// The number of motors in the robot
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 
-  std::vector<JointMoteus> joints_; /// Joint vector for the robot, owns all state information
+  // std::vector<JointMoteus> joints_; /// Joint vector for the robot, owns all state information
+  std::vector< std::shared_ptr<JointMoteus>> joints_;
   std::vector<std::reference_wrapper<const float>> positions_;  /// Vector of the motor positions (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> velocities_; /// Vector of the motor velocities (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)
-  std::vector<std::reference_wrapper<const ::mjbots::moteus::Mode>> modes_; /// Vector of the torque command sent to motors (references to the members of joints_)
+  std::vector<std::reference_wrapper<const ::mjbots::moteus::Mode>> modes_; /// Vector of current moteus modes (references to the members of joints_)
   
   std::shared_ptr<bool> timeout_ = std::make_shared<bool>(false);                   /// True if communication has timed out
   u_int64_t cycle_count_ = 0;               /// How many cycles have happened, used for soft Start

--- a/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
@@ -33,7 +33,7 @@ struct RealtimeParams {
 class MjbotsRobotInterface {
  public:
 
-  std::vector< std::shared_ptr<JointMoteus>> joints; /// Joint vector for the robot, shares state information
+  std::vector< std::shared_ptr<JointMoteus>> joints; /// Vector of shared pointers to joints for the robot, shares state information
 
   /*!
    * @brief constructs an mjbots_robot_interface to communicate with a collection of moeteusses
@@ -109,23 +109,36 @@ class MjbotsRobotInterface {
   std::vector<::mjbots::moteus::Mode> GetJointModes();
 
 
-  /**
-   * @brief Get vector of shared_ptr to joint objects
-   * 
-   * @param joint_indices 
-   * @return std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> 
+  /*!
+   * @brief Get sub-vector of shared_ptr to joint objects via a set of indices
+   * @param joint_indices set of desired joint indices as std::vector of ints
+   * @return a vector shared pointers to the desired joints
    */
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::vector<int> joint_indices);
-    /**
-   * \overload
+
+  /*!
+   * @brief Get sub-vector of shared_ptr to joint objects via a set of indices
+   * @param joint_indices set of desired joint indices std::initializer_list of ints
+   * @return a vector shared pointers to the desired joints
    */
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::initializer_list<int> joint_indices);
-    /**
-   * \overload
+
+  /*!
+   * @brief Get sub-vector of shared_ptr to joint objects via a set of indices
+   * @param joint_indices set of desired joint indices std::array of ints
+   * @return a vector shared pointers to the desired joints
    */
   template <size_t N>
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::array<int,N> joint_indices);
- 
+
+  /*!
+   * @brief Get the vector of shared_ptrs to joints 
+   * @note Added getter to public member for interface consistency with subvector getters
+   * @param joint_indices set of desired joint indices std::initializer_list of ints
+   * @return a vector shared pointers to the desired joints
+   */
+  std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(){return joints;}
+
  private:
   int num_servos_;                         /// The number of motors in the robot
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus

--- a/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <map>
 #include <future>
+#include <memory>
 #include "kodlab_mjbots_sdk/moteus_protocol.h"
 #include "kodlab_mjbots_sdk/joint_moteus.h"
 #include "kodlab_mjbots_sdk/pi3hat_moteus_interface.h"
@@ -123,12 +124,12 @@ class MjbotsRobotInterface {
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::array<int,N> joint_indices);
  
 
+  std::vector< std::shared_ptr<JointMoteus>> joints;
  private:
   int num_servos_;                         /// The number of motors in the robot
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 
   // std::vector<JointMoteus> joints_; /// Joint vector for the robot, owns all state information
-  std::vector< std::shared_ptr<JointMoteus>> joints_;
   std::vector<std::reference_wrapper<const float>> positions_;  /// Vector of the motor positions (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> velocities_; /// Vector of the motor velocities (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)

--- a/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
@@ -32,6 +32,9 @@ struct RealtimeParams {
 
 class MjbotsRobotInterface {
  public:
+
+  std::vector< std::shared_ptr<JointMoteus>> joints; /// Joint vector for the robot, shares state information
+
   /*!
    * @brief constructs an mjbots_robot_interface to communicate with a collection of moeteusses
    * @param joint_list a list of joints defining the motors in the robot
@@ -123,13 +126,10 @@ class MjbotsRobotInterface {
   template <size_t N>
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::array<int,N> joint_indices);
  
-
-  std::vector< std::shared_ptr<JointMoteus>> joints;
  private:
   int num_servos_;                         /// The number of motors in the robot
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 
-  // std::vector<JointMoteus> joints_; /// Joint vector for the robot, owns all state information
   std::vector<std::reference_wrapper<const float>> positions_;  /// Vector of the motor positions (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> velocities_; /// Vector of the motor velocities (references to the members of joints_)
   std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)

--- a/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_robot_interface.h
@@ -104,6 +104,25 @@ class MjbotsRobotInterface {
    */
   std::vector<::mjbots::moteus::Mode> GetJointModes();
 
+
+  /**
+   * @brief Get vector of shared_ptr to joint objects
+   * 
+   * @param joint_indices 
+   * @return std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> 
+   */
+  std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::vector<int> joint_indices);
+    /**
+   * \overload
+   */
+  std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::initializer_list<int> joint_indices);
+    /**
+   * \overload
+   */
+  template <size_t N>
+  std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> GetJoints(std::array<int,N> joint_indices);
+ 
+
  private:
   int num_servos_;                         /// The number of motors in the robot
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus

--- a/src/mjbots_robot_interface.cpp
+++ b/src/mjbots_robot_interface.cpp
@@ -11,7 +11,7 @@
 
 namespace kodlab::mjbots {
 void MjbotsRobotInterface::InitializeCommand() {
-  for (const auto &joint : joints_) {
+  for (const auto &joint : joints) {
     commands_.push_back({});
     commands_.back().id = joint->get_can_id(); //id
   }
@@ -56,18 +56,18 @@ MjbotsRobotInterface::MjbotsRobotInterface(const std::vector<JointMoteus> &joint
   for (JointMoteus joint: joint_list){
     // Make vector of shared_pointer objects using joint copy constructer 
     // (original list will be descoped)
-    joints_.push_back(std::make_shared<JointMoteus>(joint)); 
+    joints.push_back(std::make_shared<JointMoteus>(joint)); 
   }
 
-  for( auto & j: joints_){
+  for( auto & j: joints){
     positions_.push_back( j->get_position_reference() );
     velocities_.push_back( j->get_velocity_reference() );
     torque_cmd_.push_back( j->get_servo_torque_reference()   ); 
     modes_.push_back(j->get_mode_reference());
   }
-  num_servos_ = joints_.size();
+  num_servos_ = joints.size();
   for (size_t i = 0; i < num_servos_; ++i)
-    servo_bus_map_[joints_[i]->get_can_id()] = joints_[i]->get_can_bus();
+    servo_bus_map_[joints[i]->get_can_id()] = joints[i]->get_can_bus();
 
   // Create moteus interface
   ::mjbots::moteus::Pi3HatMoteusInterface::Options moteus_options;
@@ -100,7 +100,7 @@ void MjbotsRobotInterface::ProcessReply() {
   // Make sure the m_can_result is valid before waiting otherwise undefined behavior
   moteus_interface_->WaitForCycle();
   // Copy results to object so controller can use
-  for (auto & joint : joints_) {
+  for (auto & joint : joints) {
     const auto servo_reply = Get(replies_, joint->get_can_id());
     if(std::isnan(servo_reply.position)){
       std::cout<<"Missing can frame for servo: " << joint->get_can_id()<< std::endl;
@@ -124,7 +124,7 @@ void MjbotsRobotInterface::SetTorques(std::vector<float> torques) {
   soft_start_.ConstrainTorques(torques, cycle_count_);
   float torque_cmd;
   for (int servo = 0; servo < num_servos_; servo++) {
-    torque_cmd = joints_[servo]->UpdateTorque(torques[servo]);
+    torque_cmd = joints[servo]->UpdateTorque(torques[servo]);
     
   }
 }
@@ -147,7 +147,7 @@ std::vector<::mjbots::moteus::Mode> MjbotsRobotInterface::GetJointModes() {
 std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::vector<int> joint_indices){
   std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> joint_list;
   for (int ind: joint_indices){
-    joint_list.emplace_back(joints_[ind]);
+    joint_list.emplace_back(joints[ind]);
   }
   return joint_list;
 }

--- a/src/mjbots_robot_interface.cpp
+++ b/src/mjbots_robot_interface.cpp
@@ -152,17 +152,16 @@ std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface
   return joint_list;
 }
 
-template <size_t N>
-std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::array<int,N> joint_indices){
-  std::vector<int> joint_vect (joint_indices.begin(), joint_indices.end()); 
-  return MjbotsRobotInterface::GetJoints(joint_vect);
-}
-
 std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::initializer_list<int> joint_indices){
   std::vector<int> joint_vect (joint_indices); 
   return MjbotsRobotInterface::GetJoints(joint_vect);
 }
 
+template <size_t N>
+std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::array<int,N> joint_indices){
+  std::vector<int> joint_vect (joint_indices.begin(), joint_indices.end()); 
+  return MjbotsRobotInterface::GetJoints(joint_vect);
+}
 
 std::vector<float> MjbotsRobotInterface::GetJointTorqueCmd() {
   std::vector<float>torques(torque_cmd_.begin(), torque_cmd_.end());

--- a/src/mjbots_robot_interface.cpp
+++ b/src/mjbots_robot_interface.cpp
@@ -144,6 +144,26 @@ std::vector<::mjbots::moteus::Mode> MjbotsRobotInterface::GetJointModes() {
   return modes;
 }
 
+std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::vector<int> joint_indices){
+  std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> joint_list;
+  for (int ind: joint_indices){
+    joint_list.emplace_back(joints_[ind]);
+  }
+  return joint_list;
+}
+
+template <size_t N>
+std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::array<int,N> joint_indices){
+  std::vector<int> joint_vect (joint_indices.begin(), joint_indices.end()); 
+  return MjbotsRobotInterface::GetJoints(joint_vect);
+}
+
+std::vector<std::shared_ptr<::kodlab::mjbots::JointMoteus>> MjbotsRobotInterface::GetJoints(std::initializer_list<int> joint_indices){
+  std::vector<int> joint_vect (joint_indices); 
+  return MjbotsRobotInterface::GetJoints(joint_vect);
+}
+
+
 std::vector<float> MjbotsRobotInterface::GetJointTorqueCmd() {
   std::vector<float>torques(torque_cmd_.begin(), torque_cmd_.end());
   return torques;


### PR DESCRIPTION
Previously the joints were passed in by the main function through the control loop and copied as members into the robot interface. Now the main function "std::move"s  the joints (removing a possibly confusing copy). Within the robot interface the joints are now kept as shared pointers to all allow for future integration into higher level limb and robot kinematic/dynamics classes. This vector of shared pointers to joints is changed to a public member for easier access.
Finally, getter functions are added for getting a set of joint via indices.