### PR TITLE
Macro loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,51 @@ To configure the soft Start, set the `options.max_torque` and `options.soft_star
 max torque is the maximum torque per motor and the soft Start duration is how long the torque ramp should last
 in iterations of the control loop. 
 
+## Console Logging
+The `log.h` header provides a set of debug logging macros with adjustable
+logging severity levels.  In order of increasing severity, the levels are 
+`DEBUG`, `INFO`, `WARN`, `ERROR`, and `FATAL`.  
+
+The minimum level for console output is set by defining `LOG_MIN_SEVERITY` 
+(default is `DEBUG`).  Setting `LOG_MIN_SEVERITY` to `NONE` will disable macro 
+console output.
+
+Usage of the `LOG_XXXX` logging macros (where `XXXX` is `DEBUG`, `INFO`,
+etc.) is akin to using [`std::fprintf`](https://en.cppreference.com/w/cpp/io/c/fprintf).
+For example,
+```cpp
+LOG_WARN("This is a warning message.");
+LOG_ERROR("%s", "This is an error message.");
+```
+
+Conditional logging macros `LOG_IF_XXXX` are also provided, which take a leading
+conditional argument before the standard `std::fprintf` input.  For example,
+```cpp
+LOG_IF_INFO(false, "%s", "This info message will not be logged.");
+LOG_IF_FATAL(true, "This fatal message will be logged.");
+```
+
+The default output of the `LOG_*` macros follows the format 
+```
+[SEVERITY][path/to/file | function:line_no] Logged message
+```
+The output behavior can be changed by redefining the `LOG_ARGS` and `LOG_FORMAT` 
+macros.  For example, to produce output of the form 
+```
+[SEVERITY][path/to/file][line_no][function] Logging message
+```
+these macros would be redefined as follows
+```cpp
+#define LOG_ARGS(tag) tag, __FILE__, __LINE__, __func__
+#define LOG_FORMAT "[%-5s][%-15s][%d][%s] "
+```
+
+Colored terminal output is provided by default via
+[ANSI escape codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797).
+This can be disabled by defining the `NO_COLOR` macro.
+
+
+
 # Setup
 This setup sets up the PI as an access point and sets up cross compiling on the main computer.
 ## Setting up your Pi

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -13,6 +13,7 @@
 #include "LegLog.hpp"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
 #include "kodlab_mjbots_sdk/cartesian_leg.h"
+#include "kodlab_mjbots_sdk/log.h"  // provides console logging macros
 
 class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   using MjbotsControlLoop::MjbotsControlLoop;
@@ -49,7 +50,7 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
             std::abs(robot_->GetJointVelocities()[1]) < kSoftVelocityThreshold) {
           mode_ = kFlight;
           z0_ = z_;
-          std::cout << "Starting Limb mode" << std::endl;
+          LOG_INFO("Starting Limb mode.");
         }
         break;
       }
@@ -100,7 +101,6 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   }
 
   void ProcessInput() override {
-    std::cout << "Response received" << std::endl;
     kv_ = lcm_sub_.data_.kv;
     k_ = lcm_sub_.data_.k;
     k_stiff_ = lcm_sub_.data_.k_stiff;
@@ -108,6 +108,10 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
     b_stiff_ = lcm_sub_.data_.b_stiff;
     kp_ = lcm_sub_.data_.kp;
     kd_ = lcm_sub_.data_.kd;
+    LOG_INFO(
+        "Response received: { kv = % 5.2f, k = % 5.2f, k_stiff = % 5.2f, "
+        "b = % 5.2f, b_stiff = % 5.2f, kp = % 5.2f, kd = % 5.2f }",
+        kv_, k_, k_stiff_, b_, b_stiff_, kp_, kd_);
   }
 
   enum HybridMode {

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -12,6 +12,7 @@
 #include "kodlab_mjbots_sdk/joint_moteus.h"
 #include "ManyMotorLog.hpp"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
+#include "kodlab_mjbots_sdk/log.h"  // provides console logging macros
 #include <sys/mman.h>
 #include <limits>
 #include <Eigen/Core>
@@ -34,7 +35,7 @@ class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
       Eigen::VectorXf::Map(&torques[0], num_motors_) = tau;
     }
     else{
-      std::cout<<"Wrong number of motors"<<std::endl;
+      LOG_ERROR("Wrong number of motors");
     }
 
     robot_->SetTorques(torques);   

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -12,6 +12,7 @@
 #include "kodlab_mjbots_sdk/joint_moteus.h"
 #include "ManyMotorLog.hpp"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
+#include "kodlab_mjbots_sdk/log.h"  // provides console logging macros
 #include <sys/mman.h>
 #include <limits>
 #include <Eigen/Core>
@@ -50,10 +51,10 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
     Eigen::VectorXf::Map(&torques[0], num_motors_) = tau;
 
     // Print limits
-    std::cout<<"*********\n";
-    std::cout<<max_pos.transpose()<<"\n";
-    std::cout<<min_pos.transpose()<<"\n";
-    std::cout<<"*********"<<std::endl;
+    LOG_DEBUG("Max. Limits:");
+    std::cout << max_pos.transpose() << "\n";
+    LOG_DEBUG("Min. Limits:");
+    std::cout << min_pos.transpose() << "\n";
 
     robot_->SetTorques(torques);   
   }

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -11,6 +11,7 @@
 #include "kodlab_mjbots_sdk/joint_moteus.h"
 #include "ManyMotorLog.hpp"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
+#include "kodlab_mjbots_sdk/log.h"  // provides console logging macros
 #include <sys/mman.h>
 #include <Eigen/Core>
 #include <Eigen/Dense>
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
   options.attitude_rate_hz = 1000;
 
   // Create control loop
+  LOG_INFO("Constructing Spin_Joint with %zu joints.", joints.size());
   Spin_Joint control_loop(std::move(joints), options);
   // Starts the loop, and then join it
   control_loop.Start();

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -6,7 +6,39 @@
  *
  * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
  *
- * @note Define \c NO_COLOR to disable colored terminal output.
+ * This header provides a set of debug logging macros with adjustable
+ * logging severity levels.  In order of increasing severity, the levels are
+ *  - 'DEBUG' (0)
+ *  - 'INFO' (1)
+ *  - 'WARN' (2)
+ *  - 'ERROR' (3)
+ *  - 'FATAL' (4)
+ *  - 'NONE' (5)
+ *  .
+ * The minimum level for console output is set by defining `LOG_MIN_SEVERITY`
+ * (default is `DEBUG`).
+ *
+ * Usage of the `LOG_XXXX` logging macros (where `XXXX` is `DEBUG`, `INFO`,
+ * etc.) is akin to using [`std::fprintf`](https://en.cppreference.com/w/cpp/io/c/fprintf).
+ * For example,
+ *
+ * ```cpp
+ * LOG_WARN("This is a warning message.");
+ * LOG_ERROR("%s", "This is an error message.");
+ * ```
+ *
+ * Conditional logging macros are also provided, which take a leading
+ * conditional argument before the standard `std::fprintf` input.  For example
+ *
+ * ```cpp
+ * LOG_IF_INFO(false, "%s", "This info message will not be logged.");
+ * LOG_IF_FATAL(true, "This fatal message will be logged.");
+ * ```
+ *
+ * Colored terminal output is provided by default via
+ * [ANSI escape codes](https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797).
+ * This can be disabled by defining the `NO_COLOR` macro.
+ *
  */
 
 #pragma once

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -1,0 +1,165 @@
+/**
+ * @file log.h
+ * @author Ethan J. Musser (emusser@seas.upenn.edu)
+ * @brief Macros for logging to console
+ * @date 2022-07-13
+ *
+ * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
+ *
+ * @note Define \c NO_COLOR to disable colored terminal output.
+ */
+
+#pragma once
+
+#include <iostream>
+
+///////////////////////////////////////////////////////////////////////////////
+// Console Printing                                                          //
+///////////////////////////////////////////////////////////////////////////////
+
+// String Formatting
+#define NEWLINE "\n"
+
+// OStreams
+#define STDERR stderr
+#define STDOUT stdout
+
+// Colors
+#define COLOR_RESET "\x1b[0m"
+#define COLOR_BLACK "\x1b[30m"
+#define COLOR_RED "\x1b[31m"
+#define COLOR_GREEN "\x1b[32m"
+#define COLOR_YELLOW "\x1b[33m"
+#define COLOR_BLUE "\x1b[34m"
+#define COLOR_MAGENTA "\x1b[35m"
+#define COLOR_CYAN "\x1b[36m"
+#define COLOR_WHITE "\x1b[37m"
+#define COLOR_BLACK_BOLD "\x1b[1;30m"
+#define COLOR_RED_BOLD "\x1b[1;31m"
+#define COLOR_GREEN_BOLD "\x1b[1;32m"
+#define COLOR_YELLOW_BOLD "\x1b[1;33m"
+#define COLOR_BLUE_BOLD "\x1b[1;34m"
+#define COLOR_MAGENTA_BOLD "\x1b[1;35m"
+#define COLOR_CYAN_BOLD "\x1b[1;36m"
+#define COLOR_WHITE_BOLD "\x1b[1;37m"
+
+// Console printing via ostreams
+#define PRINT(ostream, ...) std::fprintf(ostream, __VA_ARGS__)
+
+// Color printing
+#ifndef NO_COLOR
+#define PRINT_COLOR(ostream, color, str, ...) std::fprintf(ostream, str, __VA_ARGS__)
+#else
+#define PRINT_COLOR(ostream, color, str, ...) PRINT(ostream, __VA_ARGS__)
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Logging                                                                   //
+///////////////////////////////////////////////////////////////////////////////
+
+// Log Severity Levels
+#define SEVERITY_DEBUG 0
+#define SEVERITY_INFO 1
+#define SEVERITY_WARN 2
+#define SEVERITY_ERROR 3
+#define SEVERITY_FATAL 4
+#define SEVERITY_NONE 5
+
+// Log Severity Tags
+#define TAG_DEBUG "DEBUG"
+#define TAG_INFO "INFO"
+#define TAG_WARN "WARN"
+#define TAG_ERROR "ERROR"
+#define TAG_FATAL "FATAL"
+#define TAG_NONE "NONE"
+
+// Log Severity Tags
+#define COLOR_DEBUG COLOR_BLUE
+#define COLOR_INFO COLOR_WHITE
+#define COLOR_WARN COLOR_YELLOW
+#define COLOR_ERROR COLOR_RED
+#define COLOR_FATAL COLOR_RED_BOLD
+
+// Log arguments & formatting flags
+// TODO(ethanmusser): Add time to log output.
+#define LOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
+#define LOG_FORMAT "[%-5s][%-15s | %s:%d] "
+
+// Default ostream (default STDERR)
+#ifndef LOG_OSTREAM
+#define LOG_OSTREAM STDERR
+#endif
+
+// Log to console
+// TODO(ethanmusser): Implement logging to file.
+#define LOG(msg, tag, args...) PRINT(LOG_OSTREAM, LOG_FORMAT msg NEWLINE, LOG_ARGS(tag), ##args)
+#ifndef NO_COLOR
+#define LOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color LOG_FORMAT msg NEWLINE COLOR_RESET, LOG_ARGS(tag), ##args)
+#else
+#define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
+#endif
+
+// Minimum log severity (default DEBUG)
+#ifndef LOG_MIN_SEVERITY
+#define LOG_MIN_SEVERITY SEVERITY_DEBUG
+#endif
+
+// Debug logging
+#if LOG_MIN_SEVERITY <= DEBUG_LEVEL
+#define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+#else
+#define LOG_DEBUG(message, args...)
+#endif
+
+// Info logging
+#if LOG_MIN_SEVERITY <= INFO_LEVEL
+#define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+#else
+#define LOG_INFO(message, args...)
+#endif
+
+// Warn logging
+#if LOG_MIN_SEVERITY <= WARN_LEVEL
+#define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+#else
+#define LOG_WARN(message, args...)
+#endif
+
+// Error logging
+#if LOG_MIN_SEVERITY <= ERROR_LEVEL
+#define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+#else
+#define LOG_ERROR(message, args...)
+#endif
+
+// Fatal logging
+#if LOG_MIN_SEVERITY <= FATAL_LEVEL
+#define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+#else
+#define LOG_FATAL(message, args...)
+#endif
+
+// Conditional logs (always defined)
+#if LOG_MIN_SEVERITY <= NONE_LEVEL
+#define LOG_IF_DEBUG(condition, message, args...) \
+    if (condition)                                \
+    LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+#define LOG_IF_INFO(condition, message, args...) \
+    if (condition)                               \
+    LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+#define LOG_IF_WARN(condition, message, args...) \
+    if (condition)                               \
+    LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+#define LOG_IF_ERROR(condition, message, args...) \
+    if (condition)                                \
+    LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+#define LOG_IF_FATAL(condition, message, args...) \
+    if (condition)                                \
+    LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+#else
+#define LOG_IF_INFO(condition, message, args...)
+#define LOG_IF_INFO(condition, message, args...)
+#define LOG_IF_WARN(condition, message, args...)
+#define LOG_IF_ERROR(condition, message, args...)
+#define LOG_IF_FATAL(condition, message, args...)
+#endif

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -5,6 +5,8 @@
  * @date 2022-07-13
  *
  * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
+ * 
+ * @todo(ethanmusser) Implement stack trace.
  *
  * This header provides a set of debug logging macros with adjustable
  * logging severity levels.  In order of increasing severity, the levels are

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -57,23 +57,26 @@
 #define STDOUT stdout
 
 // Colors
-#define COLOR_RESET "\x1b[0m"
-#define COLOR_BLACK "\x1b[30m"
-#define COLOR_RED "\x1b[31m"
-#define COLOR_GREEN "\x1b[32m"
-#define COLOR_YELLOW "\x1b[33m"
-#define COLOR_BLUE "\x1b[34m"
-#define COLOR_MAGENTA "\x1b[35m"
-#define COLOR_CYAN "\x1b[36m"
-#define COLOR_WHITE "\x1b[37m"
-#define COLOR_BLACK_BOLD "\x1b[1;30m"
-#define COLOR_RED_BOLD "\x1b[1;31m"
-#define COLOR_GREEN_BOLD "\x1b[1;32m"
-#define COLOR_YELLOW_BOLD "\x1b[1;33m"
-#define COLOR_BLUE_BOLD "\x1b[1;34m"
-#define COLOR_MAGENTA_BOLD "\x1b[1;35m"
-#define COLOR_CYAN_BOLD "\x1b[1;36m"
-#define COLOR_WHITE_BOLD "\x1b[1;37m"
+#define CONSOLE_SEQ_ESC "\x1b"
+#define CONSOLE_SEQ_BEG "["
+#define CONSOLE_SEQ_SEP ";"
+#define CONSOLE_SEQ_END "m"
+#define FONT_REG "0"
+#define FONT_BOLD "1"
+#define COLOR_RESET "0"
+#define COLOR_BLACK "30"
+#define COLOR_RED "31"
+#define COLOR_GREEN "32"
+#define COLOR_YELLOW "33"
+#define COLOR_BLUE "34"
+#define COLOR_MAGENTA "35"
+#define COLOR_CYAN "36"
+#define COLOR_WHITE "37"
+
+// Color Convenience
+#define FMT_TEXT(font, color) \
+  CONSOLE_SEQ_ESC CONSOLE_SEQ_BEG font CONSOLE_SEQ_SEP color CONSOLE_SEQ_END
+#define RESET_COLOR FMT_TEXT(FONT_REG, COLOR_RESET)
 
 // Console printing via ostreams
 #define PRINT(ostream, ...) std::fprintf(ostream, __VA_ARGS__)
@@ -106,11 +109,11 @@
 #define TAG_NONE "NONE"
 
 // Log Severity Tags
-#define COLOR_DEBUG COLOR_BLUE
-#define COLOR_INFO COLOR_WHITE
-#define COLOR_WARN COLOR_YELLOW
-#define COLOR_ERROR COLOR_RED
-#define COLOR_FATAL COLOR_RED_BOLD
+#define COLOR_DEBUG FMT_TEXT(FONT_REG, COLOR_BLUE)
+#define COLOR_INFO FMT_TEXT(FONT_REG, COLOR_WHITE)
+#define COLOR_WARN FMT_TEXT(FONT_REG, COLOR_YELLOW)
+#define COLOR_ERROR FMT_TEXT(FONT_REG, COLOR_RED)
+#define COLOR_FATAL FMT_TEXT(FONT_BOLD, COLOR_RED)
 
 // Log arguments & formatting flags
 // TODO(ethanmusser): Add time to log output.
@@ -126,7 +129,7 @@
 // TODO(ethanmusser): Implement logging to file.
 #define LOG(msg, tag, args...) PRINT(LOG_OSTREAM, LOG_FORMAT msg NEWLINE, LOG_ARGS(tag), ##args)
 #ifndef NO_COLOR
-#define LOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color LOG_FORMAT msg NEWLINE COLOR_RESET, LOG_ARGS(tag), ##args)
+#define LOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color LOG_FORMAT msg NEWLINE RESET_COLOR, LOG_ARGS(tag), ##args)
 #else
 #define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,9 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/abstract_realtime_object.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/mjbots_control_loop.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_base.h"
-                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_moteus.h")
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_moteus.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/log.h"
+                )
 
 set(SOURCE_LIST "pi3hat.cpp" 
                 "mjbots_robot_interface.cpp"


### PR DESCRIPTION
Provides macro logging infrastructure in `log.h`.  Logging macros document relevant status information with `fprintf`-like syntax.  Simpler to use than the present `ostream` method.


### Possible Additions

- Blurb detailing usage in the `README.md` or wiki
- Logging to a file
- Adding time to displayed output
- Implementing timing capabilities


### Usage

The input 
```cpp
LOG_DEBUG("Debug message.");
LOG_INFO("%s message.", "Info");
LOG_WARN("%s %s.", "Warn", "message");
LOG_ERROR("Error message. Error code: %d.", 10);
LOG_FATAL("Fatal message.");

LOG_IF_DEBUG(true, "This debug message will print.");
LOG_IF_INFO(false, "This info message won't print");
LOG_IF_WARN(true, "String substitution works in this %s if statement.", "warn");
LOG_IF_ERROR(0 < 1, "Error message will print.  (0 < 1) = %d", 0 < 1);
LOG_IF_FATAL(1 == 2, "Fatal message will not print.");
```
produces the following output when called in the `/home/ethan/kodlab_mjbots_sdk/examples/spin_joints_example.cpp` `main` function on lines spanning 61 - 70.
![Screenshot from 2022-07-27 18-08-23](https://user-images.githubusercontent.com/15707116/181381150-d1894523-1e2d-4a05-8a40-8e4c2fd05d14.png)