### PR TITLE
adds yaml-cpp submodule for config files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "thirdparty/real_time_tools"]
 	path = thirdparty/real_time_tools
 	url = git@github.com:KodlabPenn/real_time_tools.git
+[submodule "thirdparty/yaml-cpp"]
+	path = thirdparty/yaml-cpp
+	url = git@github.com:jbeder/yaml-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,4 @@ add_subdirectory(src)
 # The executable code is here
 add_subdirectory(examples)
 add_subdirectory(thirdparty/real_time_tools)
+add_subdirectory(thirdparty/yaml-cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,9 @@ add_library(kodlab_mjbots_sdk  ${SOURCE_LIST} ${HEADER_LIST})
 target_include_directories(kodlab_mjbots_sdk PUBLIC ../include ../thirdparty/Eigen ../lcm_types
         $ENV{RASPBIAN_ROOTFS}/opt/vc/include
         $ENV{RASPBIAN_ROOTFS}/usr/local/include
-        ../thirdparty/real_time_tools/include)
+        ../thirdparty/real_time_tools/include
+        ../thirdparty/yaml-cpp/include
+        )
 
 target_link_libraries(kodlab_mjbots_sdk PUBLIC $ENV{RASPBIAN_ROOTFS}/opt/vc/lib/libbcm_host.so)
 


### PR DESCRIPTION
Adds a YAML submodule from [yaml-cpp](https://github.com/jbeder/yaml-cpp ). Currently not used in kodlab examples, so not included in `examples/CMakeLists.txt` as a dependency. Useful for writing and editing robot configuration files.