### PR TITLE
Added names and helper classes to joint base and moteus

### DIFF
--- a/include/kodlab_mjbots_sdk/common_header.h
+++ b/include/kodlab_mjbots_sdk/common_header.h
@@ -3,6 +3,9 @@
 #pragma once
 #include <atomic>
 #include <signal.h>  // manage the ctrl+c signal
+#include <type_traits>
+#include <iostream>
+#include <vector>
 
 namespace kodlab {
 /**

--- a/include/kodlab_mjbots_sdk/common_header.h
+++ b/include/kodlab_mjbots_sdk/common_header.h
@@ -3,9 +3,6 @@
 #pragma once
 #include <atomic>
 #include <signal.h>  // manage the ctrl+c signal
-#include <type_traits>
-#include <iostream>
-#include <vector>
 
 namespace kodlab {
 /**

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -74,6 +74,13 @@ class JointBase {
         void set_velocity(float vel){velocity_ = vel;}
 
         /**
+         * @brief Set the joint zero offset
+         * 
+         * @param zero zero offset override
+         */
+        void set_zero(float zero){zero_offset_ = zero;}
+
+        /**
          * @brief Get the position
          * 
          * @return float 
@@ -165,7 +172,7 @@ class JointBase {
         // Limits
         float max_torque_    =  std::numeric_limits<float>::infinity(); /// max torque [N m]
         float pos_limit_min_ = -std::numeric_limits<float>::infinity(); /// max position [rad] before soft stop
-        float pos_limit_max_ = -std::numeric_limits<float>::infinity(); /// min position [rad] before soft stop
+        float pos_limit_max_ =  std::numeric_limits<float>::infinity(); /// min position [rad] before soft stop
 
 };
 

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -11,6 +11,9 @@
 
 #pragma once
 #include <limits>
+#include <memory>
+#include <vector>
+#include <type_traits>
 
 /**
  * Abstract joint state class with torque and joint pose limiting capabilities.
@@ -166,3 +169,41 @@ class JointBase {
 
 };
 
+
+/*!
+ * @brief Helper class to wrap the vector of shared pointers of JointBaseDerived
+ * 
+ * @tparam joint_type must be JointBaseDerived type
+ */
+template <class joint_type>
+class JointSharedVector
+{
+    static_assert(std::is_base_of<JointBase, joint_type>::value); // check that the joint_type is derived from JointBase
+    std::vector<std::shared_ptr<joint_type>> v_;  // internal vector of shared pointers 
+
+public:
+    /*!
+     * @brief constructs a shared_ptr joint_type and appends it to the internal vector
+     * 
+     * @tparam Args parameter pack for passing through the joint constructor
+     * @param args a set of args that match the joint_type constructor
+     */
+    template <typename... Args>
+    void addJoint(Args... args)
+    {
+        v_.push_back(std::make_shared<joint_type>(args...));
+    }
+
+    /*!
+     * @brief implicit conversion to vector that returns a copy of the shared_ptr's
+     * 
+     * @return std::vector<std::shared_ptr<joint_type>> 
+     */
+    operator std::vector<std::shared_ptr<joint_type>>() { return v_; }
+    /*!
+     * @brief get a reference to the ith instance of joint_type
+     * 
+     * @return joint_type>
+     */
+    joint_type & operator[](size_t i) {return *(v_[i]);}
+};

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -14,6 +14,8 @@
 #include <memory>
 #include <vector>
 #include <type_traits>
+#include <string>
+
 
 /**
  * Abstract joint state class with torque and joint pose limiting capabilities.
@@ -24,6 +26,28 @@
 class JointBase {
 
     public:
+
+        /**
+         * @brief Construct a new Joint Base object with a name
+         * 
+         * @param name          /// Sets the joint name
+         * @param direction     /// 1 or -1, flips positive rotation direction (Default:1)
+         * @param zero_offset   /// offset [rad] of joint zero position (Default:0) 
+         * @param gear_ratio    /// Gear ratio joint to servo (ratio>1 means slower joint) (Default:1.0)
+         * @param max_torque    /// Maximum torque of the joint [N m] (Default:inf)
+         * @param pos_min       /// Minimum joint limit before taking protective measures such as torque limiting or shut off (Default:inf)
+         * @param pos_max       /// Maximum joint limit before taking protective measures such as torque limiting or shut off (Default:-inf)
+         */
+        JointBase(
+                std::string name,
+                int direction = 1, 
+                float zero_offset = 0,
+                float gear_ratio = 1.0, 
+                float max_torque = std::numeric_limits<float>::infinity(),
+                float pos_min = -std::numeric_limits<float>::infinity(), 
+                float pos_max = std::numeric_limits<float>::infinity()
+                );
+
         /**
          * @brief Construct a new Joint Base object
          * 
@@ -79,6 +103,13 @@ class JointBase {
          * @param zero zero offset override
          */
         void set_zero(float zero){zero_offset_ = zero;}
+
+        /**
+         * @brief Set the joint name
+         *
+         * @param name New joint name
+         */
+        void set_name(std::string name) { name_ = name; }
 
         /**
          * @brief Get the position
@@ -150,7 +181,15 @@ class JointBase {
          */
         const float get_pos_limit_max() const {return pos_limit_max_; }
 
+        /**
+         * @brief Get the joint name
+         *
+         * @return name as string
+         */
+        const std::string get_name() const { return name_; }
+
     protected:
+        std::string name_ = "";  // Optional joint name
         // Joint Params
         float gear_ratio_  = 1.0;   /// external joint gear ratio
         float zero_offset_ = 0;     /// zero offset [rad]

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -23,13 +23,13 @@ namespace mjbots{
 struct MoteusJointConfig{
     int can_id;
     int can_bus;
+    std::string name = "";
     int direction = 1; 
     float zero_offset = 0;
     float gear_ratio = 1.0;
     float max_torque = std::numeric_limits<float>::infinity();
     float pos_min = -std::numeric_limits<float>::infinity();
     float pos_max = std::numeric_limits<float>::infinity();
-    std::string name = "";
 };
 
 /**         
@@ -37,10 +37,37 @@ struct MoteusJointConfig{
  * moteus motor driver powered joint 
  * 
  */
-class JointMoteus: public JointBase{
+class JointMoteus: public JointBase
+{
     public:
         /**
          * @brief Construct a new Joint Moteus object
+         * 
+         * @param name         /// name string for this joint
+         * @param can_id       /// the can id of this joint's moteus [1-127]
+         * @param can_bus      /// the can bus the moteus communicates on [1-4]
+         * @param direction     /// 1 or -1, flips positive rotation direction (Default:1)
+         * @param zero_offset   /// offset [rad] of joint zero position from servo zero postition (Default:0)
+         * @param gear_ratio    /// Gear ratio joint to servo (ratio>1 means slower joint) (Default:1.0)
+         * @param max_torque    /// Maximum torque limit of the joint [N m] (Default:inf)
+         * @param pos_min       /// Minimum joint pose limit before taking protective measures such as torque limiting or shut off (Default:-inf)
+         * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
+         */
+        JointMoteus(
+            std::string name,
+            int can_id,
+            int can_bus,
+            int direction = 1,
+            float zero_offset = 0,
+            float gear_ratio = 1.0,
+            float max_torque = std::numeric_limits<float>::infinity(),
+            float pos_min = -std::numeric_limits<float>::infinity(),
+            float pos_max = std::numeric_limits<float>::infinity())
+            : JointBase(name, direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
+              can_bus_(can_bus), can_id_(can_id) {}
+
+        /**
+         * @brief Construct a new Joint Moteus object without name
          * 
          * @param can_id       /// the can id of this joint's moteus [1-127]
          * @param can_bus      /// the can bus the moteus communicates on [1-4]
@@ -52,17 +79,17 @@ class JointMoteus: public JointBase{
          * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
          */
         JointMoteus(
-            int can_id, 
+            int can_id,
             int can_bus,
-            int direction = 1, 
+            int direction = 1,
             float zero_offset = 0,
-            float gear_ratio = 1.0, 
+            float gear_ratio = 1.0,
             float max_torque = std::numeric_limits<float>::infinity(),
-            float pos_min = -std::numeric_limits<float>::infinity(), 
-            float pos_max = std::numeric_limits<float>::infinity()
-            )
-            :JointBase(direction,zero_offset,gear_ratio,max_torque,pos_min,pos_max),
-            can_bus_(can_bus), can_id_(can_id){}
+            float pos_min = -std::numeric_limits<float>::infinity(),
+            float pos_max = std::numeric_limits<float>::infinity())
+            : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
+              can_bus_(can_bus), can_id_(can_id) {}
+
 
         /**
          * @brief Construct a new Joint Moteus object with a MoteusJointConfig struct
@@ -70,7 +97,8 @@ class JointMoteus: public JointBase{
          * @param config MoteusJointConfig input
          */
         JointMoteus(MoteusJointConfig config)
-            : JointBase( config.direction,
+            : JointBase( config.name,
+                         config.direction,
                          config.zero_offset,
                          config.gear_ratio,
                          config.max_torque,

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -2,7 +2,6 @@
  * @file joint_moteus.h
  * @author J. Diego Caporale (jdcap@seas.upenn.edu)
  * @brief Moteus powered joint class
- * @version 0.1
  * @date 2022-02-22
  * 
  * @copyright BSD 3-Clause License, Copyright (c) 2021 The Trustees of the University of Pennsylvania. All Rights Reserved

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -12,24 +12,38 @@
 #pragma once
 #include "kodlab_mjbots_sdk/joint_base.h"
 #include "kodlab_mjbots_sdk/moteus_protocol.h"
+#include <string>
 
 namespace kodlab{
 namespace mjbots{
+/**
+ * @brief struct for storing or passing moteus joint configurations
+ * 
+ */
+struct MoteusJointConfig{
+    int can_id;
+    int can_bus;
+    int direction = 1; 
+    float zero_offset = 0;
+    float gear_ratio = 1.0;
+    float max_torque = std::numeric_limits<float>::infinity();
+    float pos_min = -std::numeric_limits<float>::infinity();
+    float pos_max = std::numeric_limits<float>::infinity();
+    std::string name = "";
+};
+
 /**         
- * A JointBase child class that encapsulates parameters and functions of 
+ * @brief A JointBase derived class that encapsulates parameters and functions of 
  * moteus motor driver powered joint 
- * @brief 
- * Moteus Joint class 
+ * 
  */
 class JointMoteus: public JointBase{
     public:
         /**
-
-         *
          * @brief Construct a new Joint Moteus object
          * 
-         * @param can_bus      /// the can bus the moteus communicates on [1-4]
          * @param can_id       /// the can id of this joint's moteus [1-127]
+         * @param can_bus      /// the can bus the moteus communicates on [1-4]
          * @param direction     /// 1 or -1, flips positive rotation direction (Default:1)
          * @param zero_offset   /// offset [rad] of joint zero position from servo zero postition (Default:0)
          * @param gear_ratio    /// Gear ratio joint to servo (ratio>1 means slower joint) (Default:1.0)
@@ -49,6 +63,21 @@ class JointMoteus: public JointBase{
             )
             :JointBase(direction,zero_offset,gear_ratio,max_torque,pos_min,pos_max),
             can_bus_(can_bus), can_id_(can_id){}
+
+        /**
+         * @brief Construct a new Joint Moteus object with a MoteusJointConfig struct
+         * 
+         * @param config MoteusJointConfig input
+         */
+        JointMoteus(MoteusJointConfig config)
+            : JointBase( config.direction,
+                         config.zero_offset,
+                         config.gear_ratio,
+                         config.max_torque,
+                         config.pos_min,
+                         config.pos_max),
+              can_id_( config.can_id),
+              can_bus_( config.can_bus) {}
         
         /**
          * @brief Update the joint of the moteus. Converts rot/s to rad/s and saves mode

--- a/src/joint_base.cpp
+++ b/src/joint_base.cpp
@@ -2,28 +2,44 @@
  * @file joint_base.cpp
  * @author Kodlab - J. Diego Caporale (jdcap@seas.upenn.edu)
  * @brief Class implementation for JointBase.
- * @version 0.1
  * @date 2022-03-21
  * 
  * @copyright BSD 3-Clause License, Copyright (c) 2021 The Trustees of the University of Pennsylvania. All Rights Reserved
  * 
  */
 
+#include <iostream>
 #include "kodlab_mjbots_sdk/joint_base.h"
-JointBase::JointBase(
-                int direction, 
-                float zero_offset,
-                float gear_ratio, 
-                float max_torque,
-                float pos_min, 
-                float pos_max)
-                :direction_(direction), zero_offset_(zero_offset), 
-                 max_torque_(max_torque), gear_ratio_(gear_ratio),
-                 pos_limit_min_(pos_min), pos_limit_max_(pos_max){
-                    // Set to sign if not -1 or 1
-                    direction_ = (direction_ >= 0) - (direction_ < 0); 
-                    gear_ratio_ = gear_ratio_ == 0 ? 1.0 : gear_ratio_;
-                }
+
+JointBase::JointBase(std::string name,
+                     int direction,
+                     float zero_offset,
+                     float gear_ratio,
+                     float max_torque,
+                     float pos_min,
+                     float pos_max)
+    : name_(name), direction_(direction), zero_offset_(zero_offset),
+      max_torque_(max_torque), gear_ratio_(gear_ratio),
+      pos_limit_min_(pos_min), pos_limit_max_(pos_max)
+{
+    // Set to sign if not -1 or 1
+    direction_ = (direction_ >= 0) - (direction_ < 0);
+    // Don't allow zero or negative gear ratio
+    if (gear_ratio <= 0)
+    {
+        //TODO Replace with LOG_WARN
+        std::cout << "Warning: Gear ratio must be positive. \nGear ratio reset to 1.0" << std::endl;
+        gear_ratio_ = 1.0;
+    }
+}
+
+JointBase::JointBase(int direction,
+                     float zero_offset,
+                     float gear_ratio,
+                     float max_torque,
+                     float pos_min,
+                     float pos_max)
+    : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max) {}
 
 float JointBase::UpdateTorque(float joint_torque){
     // Clip max torque


### PR DESCRIPTION
This PR 
- adds name member to the JointBase and JointMoteus classes and constructors
- fixes a small bug in the joint base default for pos_max
- adds the JointSharedVector class
- adds the MoteusJointConfig struct for simpler construction
- and fixes some formatting and commenting errors