### PR TITLE
Doxygen action workflow

### DIFF
--- a/.github/workflows/doxygen-action.yml
+++ b/.github/workflows/doxygen-action.yml
@@ -1,0 +1,27 @@
+name: Doxygen Documentation
+
+on:
+  push:
+    branches:
+      - master
+  page_build:
+
+jobs:
+  doxygen:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1.9.4
+      - name: Build Doxygen documentation
+        uses: mattnotmitt/doxygen-action@v1
+        with:
+          doxyfile-path: ./Doxyfile
+      - name: Deploy Documentation
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/html
+          publish_branch: gh-pages
+          commit_message: '[ci skip] ${{ github.event.head_commit.message }}'


### PR DESCRIPTION
This action will build the Doxygen documentation and publish the results to the repository's GitHub pages page. The action depends on having a `Doxyfile` present, and would interface with that provided in #33.

### GitHub Pages Deployment

- An [SSH deploy key](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-create-ssh-deploy-key) or [`GITHUB_TOKEN`](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-first-deployment-with-github_token) must be configured to deploy to GitHub pages via the `peaceiris/actions-gh-pagesaction` action used in this workflow.  This is configured in the repository settings.
- The documentation will build into and deploy from the `gh-pages` branch.