### PR TITLE
Changing naming convention in RobotBase, MJBotsInterface, MJBotsControlLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for better realtime performance
 3. Integration with LCM (https://lcm-proj.github.io/) for remote logging and remote input to the robot
 4.  The `MjbotsControlLoop` object which handles the structure of the control loop for
 the easy creation of new controllers
-5. The `MjbotsRobotInterface` which provides a convenient interface for communicating with any number
+5. The `MjbotsHardwareInterface` which provides a convenient interface for communicating with any number
 of moteus motor controllers 
 
 Note: This library only supports torque commands. If you wish to use

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ In order to keep the message size down, kp and kd on the motors must be set to 0
 # Usage
 ## MjbotsControlLoop:
 To use the `MjbotsControlLoop` create a class which inherits the `MjbotsControlLoop`
-and implements `CalcTorques` to set the torques in the robot object. 
+and implements `Update` to set the torques in the robot object. 
 
     class Controller : public MjbotsControlLoop{
       using MjbotsControlLoop::MjbotsControlLoop;
-      void CalcTorques() override{
+      void Update() override{
         std::vector<float> torques = control_effort;
         robot_->SetTorques(torques);
       }    

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ for better realtime performance
 the easy creation of new controllers
 5. The `MjbotsHardwareInterface` which provides a convenient interface for communicating with any number
 of moteus motor controllers 
-6. The `RobotInterface` which provides and interface for updating robot state and joint torques.
+6. The `RobotBase` class which provides an interface for updating robot state and joint torques.
 
 Note: This library only supports torque commands. If you wish to use
 position control, you either must close the loop yourself or modify the 
@@ -38,7 +38,7 @@ class MyControlLoop : public kodlab::mjbots::MjbotsControlLoop
 
 A simple example using the `MjbotsControlLoop` is provided in
 `examples/spint_joints_example.cpp`.  The `MjbotsControlLoop` is optionally templated with an LCM
-log type, an LCM input type, and a `RobotInterface`-derived class. These are
+log type, an LCM input type, and a `RobotBase`-derived class. These are
 described below.
 
 ## Accessing robot state
@@ -79,16 +79,16 @@ Next, implement the `ProcessInput` function to do things with the data in `lcm_s
         gains_ = lcm_sub_.data_.gains;
       }
 
-## Robot Interface
-The `RobotInterface` object is intended to be inherited by a user-defined robot 
+## Robot Base
+The `RobotBase` object is intended to be inherited by a user-defined robot 
 class.  The derived class should implement an override of 
-`RobotInterface::Update()`.  Note that this new `Update()` function must 
+`RobotBase::Update()`.  Note that this new `Update()` function must 
 increment the cycle count.  A simple implementation follows.
 
 ```cpp
-class MyRobot : virtual public kodlab::RobotInterface
+class MyRobot : virtual public kodlab::RobotBase
 {
-  using kodlab::RobotInterface::RobotInterface;
+  using kodlab::RobotBase::RobotBase;
 
 public:
   int mode = 0; // Member variables encode whatever added state we need

--- a/examples/imu_example.cpp
+++ b/examples/imu_example.cpp
@@ -40,7 +40,7 @@ private:
   /**
    * @brief Gathers IMU data and sets command torques to zero
    */
-  void CalcTorques() override
+  void Update() override
   {
     // Update Read-Only IMUData
     imu_read_only_ = mjbots_interface_->GetIMUData();
@@ -59,7 +59,7 @@ private:
     imu_->PrintIMUData();
 
     // Set Torques to Zero
-    std::vector<float> torques(num_motors_, 0);
+    std::vector<float> torques(num_joints_, 0);
     robot_->SetTorques(torques);
   }
 

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -18,8 +18,8 @@
 class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   using MjbotsControlLoop::MjbotsControlLoop;
 
-  // We use CalcTorques as the main control loop
-  void CalcTorques() override {
+  // We use Update as the main control loop
+  void Update() override {
     std::vector<float> torques = {0, 0};
 
     // Run the FK to get leg state

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -21,18 +21,18 @@
 class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
   void Update() override {
-    std::vector<float> torques(num_motors_, 0);
+    std::vector<float> torques(num_joints_, 0);
 
-    if (num_motors_==3){
+    if (num_joints_==3){
       Eigen::Vector3f leg_pos_des;
       leg_pos_des<<1-M_PI_2,2,0;
-      Eigen::Vector3f positions  = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> ( robot_->GetJointPositions().data(), num_motors_);
-      Eigen::Vector3f velocities = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointVelocities().data(), num_motors_);
+      Eigen::Vector3f positions  = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointPositions().data(), num_joints_);
+      Eigen::Vector3f velocities = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointVelocities().data(), num_joints_);
       float kp = 100;
       float kd = 1;
       Eigen::VectorXf tau = kp*(leg_pos_des-positions) + kd*(Eigen::Vector3f::Zero()-velocities);
 
-      Eigen::VectorXf::Map(&torques[0], num_motors_) = tau;
+      Eigen::VectorXf::Map(&torques[0], num_joints_) = tau;
     }
     else{
       LOG_ERROR("Wrong number of motors");
@@ -42,13 +42,13 @@ class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 
   void PrepareLog() override {
-    for (int servo = 0; servo < num_motors_; servo++) {
+    for (int servo = 0; servo < num_joints_; servo++) {
       log_data_.positions[servo]  = robot_->GetJointPositions()[servo];
       log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
       log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
       log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
-    for (int servo = num_motors_; servo < 13; servo++) {
+    for (int servo = num_joints_; servo < 13; servo++) {
       log_data_.positions[servo] = 0;
       log_data_.velocities[servo] = 0;
       log_data_.modes[servo] = 0;

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -4,7 +4,7 @@
 // J. Diego Caporale <jdcap@seas.upenn.edu>
 
 /* Basic PD Control example script demonstrating how to use the mjbots_control_loop to 3 motors. The functions to implement are
- * CalcTorques and PrepareLog. In this example we send a PD control torques and log the motor information.
+ * Update and PrepareLog. In this example we send a PD control torques and log the motor information.
  * Also, an implementation that uses Eigen conversions.
  */
 
@@ -20,7 +20,7 @@
 
 class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
-  void CalcTorques() override {
+  void Update() override {
     std::vector<float> torques(num_motors_, 0);
 
     if (num_motors_==3){

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -23,15 +23,15 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   void Update() override {
 
     float omega_des = 0.3; //velocity in rads per sec
-    Eigen::VectorXf omega = Eigen::VectorXf::Ones(num_motors_)*omega_des; //radians
+    Eigen::VectorXf omega = Eigen::VectorXf::Ones(num_joints_)*omega_des; //radians
  
-    Eigen::VectorXf positions  = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> ( robot_->GetJointPositions().data(), num_motors_);
-    Eigen::VectorXf velocities = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointVelocities().data(), num_motors_);
+    Eigen::VectorXf positions  = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointPositions().data(), num_joints_);
+    Eigen::VectorXf velocities = Eigen::Map<Eigen::VectorXf,Eigen::Unaligned> (robot_->GetJointVelocities().data(), num_joints_);
 
     static Eigen::VectorXf  phase = positions; //radians
-    static Eigen::VectorXf    dir = Eigen::VectorXf::Ones(num_motors_); //radians
-    static Eigen::VectorXf max_pos = Eigen::VectorXf::Ones(num_motors_) * ( -std::numeric_limits<float>::infinity() );
-    static Eigen::VectorXf min_pos = Eigen::VectorXf::Ones(num_motors_) * (  std::numeric_limits<float>::infinity() );
+    static Eigen::VectorXf    dir = Eigen::VectorXf::Ones(num_joints_); //radians
+    static Eigen::VectorXf max_pos = Eigen::VectorXf::Ones(num_joints_) * ( -std::numeric_limits<float>::infinity() );
+    static Eigen::VectorXf min_pos = Eigen::VectorXf::Ones(num_joints_) * (  std::numeric_limits<float>::infinity() );
 
     phase.array() += dir.array()*(omega.array() / frequency_) ;
     
@@ -46,9 +46,9 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
     min_pos = (phase.array() < min_pos.array()).select(phase, min_pos);
     
     //Calculate torques
-    std::vector<float> torques(num_motors_, 0);
+    std::vector<float> torques(num_joints_, 0);
     Eigen::VectorXf tau = 100*(phase-positions) + 1*(omega-velocities);
-    Eigen::VectorXf::Map(&torques[0], num_motors_) = tau;
+    Eigen::VectorXf::Map(&torques[0], num_joints_) = tau;
 
     // Print limits
     LOG_DEBUG("Max. Limits:");
@@ -60,13 +60,13 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 
   void PrepareLog() override {
-    for (int servo = 0; servo < num_motors_; servo++) {
+    for (int servo = 0; servo < num_joints_; servo++) {
       log_data_.positions[servo]  = robot_->GetJointPositions()[servo];
       log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
       log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
       log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
-    for (int servo = num_motors_; servo < 13; servo++) {
+    for (int servo = num_joints_; servo < 13; servo++) {
       log_data_.positions[servo] = 0;
       log_data_.velocities[servo] = 0;
       log_data_.modes[servo] = 0;

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -4,7 +4,7 @@
 // J. Diego Caporale <jdcap@seas.upenn.edu>
 
 /* Example script running joints to their mechanical limits before switching direction. The functions to implement are
- * CalcTorques and PrepareLog. In this example we run the motor forward until its 
+ * Update and PrepareLog. In this example we run the motor forward until its
  * position error is large enough to detect a obstacle, then switching directions
  */
 
@@ -20,7 +20,7 @@
 
 class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
-  void CalcTorques() override {
+  void Update() override {
 
     float omega_des = 0.3; //velocity in rads per sec
     Eigen::VectorXf omega = Eigen::VectorXf::Ones(num_motors_)*omega_des; //radians

--- a/examples/robot_example.cpp
+++ b/examples/robot_example.cpp
@@ -23,7 +23,7 @@ class SimpleRobotControlLoop : public kodlab::mjbots::MjbotsControlLoop<ManyMoto
 {
     using MjbotsControlLoop::MjbotsControlLoop;
 
-    void CalcTorques() override
+    void Update() override
     {
         robot_->Update();
     }

--- a/examples/robot_example.cpp
+++ b/examples/robot_example.cpp
@@ -29,14 +29,14 @@ class SimpleRobotControlLoop : public kodlab::mjbots::MjbotsControlLoop<ManyMoto
     }
     void PrepareLog() override
     {
-        for (int servo = 0; servo < num_motors_; servo++)
+        for (int servo = 0; servo < num_joints_; servo++)
         {
             log_data_.positions[servo] = robot_->GetJointPositions()[servo];
             log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
             log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
             log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
         }
-        for (int servo = num_motors_; servo < 13; servo++)
+        for (int servo = num_joints_; servo < 13; servo++)
         {
             log_data_.positions[servo] = 0;
             log_data_.velocities[servo] = 0;

--- a/examples/robot_example.cpp
+++ b/examples/robot_example.cpp
@@ -14,7 +14,7 @@
 #include "kodlab_mjbots_sdk/common_header.h"
 #include "ManyMotorLog.hpp"
 #include "ModeInput.hpp"
-#include "kodlab_mjbots_sdk/robot_interface.h"
+#include "kodlab_mjbots_sdk/robot_base.h"
 #include "kodlab_mjbots_sdk/mjbots_control_loop.h"
 
 #include "examples/simple_robot.h"

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -19,18 +19,18 @@
 class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
   void Update() override {
-    std::vector<float> torques(num_motors_, 0);
+    std::vector<float> torques(num_joints_, 0);
     robot_->SetTorques(torques);
   }
 
   void PrepareLog() override {
-    for (int servo = 0; servo < num_motors_; servo++) {
+    for (int servo = 0; servo < num_joints_; servo++) {
       log_data_.positions[servo] = robot_->GetJointPositions()[servo];
       log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
       log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
       log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
-    for (int servo = num_motors_; servo < 13; servo++) {
+    for (int servo = num_joints_; servo < 13; servo++) {
       log_data_.positions[servo] = 0;
       log_data_.velocities[servo] = 0;
       log_data_.modes[servo] = 0;

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -4,7 +4,7 @@
 // Shane Rozen-Levy <srozen01@seas.upenn.edu>, J. Diego Caporale <jdcap@seas.upenn.edu>
 
 /* Basic example script demonstrating how to use the mjbots_control_loop to 2 joints. The functions to implement are
- * CalcTorques and PrepareLog. In this example we send a torque cmd of all zeros and log the motor information.
+ * Update and PrepareLog. In this example we send a torque cmd of all zeros and log the motor information.
  */
 
 #include "kodlab_mjbots_sdk/mjbots_control_loop.h"
@@ -18,7 +18,7 @@
 
 class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
-  void CalcTorques() override {
+  void Update() override {
     std::vector<float> torques(num_motors_, 0);
     robot_->SetTorques(torques);
   }

--- a/include/examples/simple_robot.h
+++ b/include/examples/simple_robot.h
@@ -1,7 +1,7 @@
 /**
  * @file simple_robot.h
  * @author J. Diego Caporale
- * @brief A simple RobotInterface derived class example. Here is where you would implement any state updates,
+ * @brief A simple RobotBase derived class example. Here is where you would implement any state updates,
  *        behaviors, or control system
  * @date 2022-07-19
  *
@@ -11,12 +11,12 @@
 
 #pragma once
 
-#include "kodlab_mjbots_sdk/robot_interface.h"
+#include "kodlab_mjbots_sdk/robot_base.h"
 
-class SimpleRobot : virtual public kodlab::RobotInterface
+class SimpleRobot : virtual public kodlab::RobotBase
 {
 
-    using kodlab::RobotInterface::RobotInterface;
+    using kodlab::RobotBase::RobotBase;
 
 public:
     int mode = 0; // Member variables encode whatever added state we need

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -8,7 +8,7 @@
 #pragma once
 #include <type_traits>
 #include "kodlab_mjbots_sdk/abstract_realtime_object.h"
-#include "kodlab_mjbots_sdk/robot_interface.h"
+#include "kodlab_mjbots_sdk/robot_base.h"
 #include "kodlab_mjbots_sdk/mjbots_hardware_interface.h"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
 #include "lcm/lcm-cpp.hpp"
@@ -47,9 +47,9 @@ struct ControlLoopOptions {
  * @tparam InputClass[optional] class for input data 
  * @tparam RobotClass[optional] RobotInterfaceDerived class that contains state and control calculations 
  */
-template<class LogClass = VoidLcm, class InputClass = VoidLcm, class RobotClass = kodlab::RobotInterface>
+template<class LogClass = VoidLcm, class InputClass = VoidLcm, class RobotClass = kodlab::RobotBase>
 class MjbotsControlLoop : public AbstractRealtimeObject {
- static_assert(std::is_base_of<kodlab::RobotInterface,RobotClass>::value);
+ static_assert(std::is_base_of<kodlab::RobotBase, RobotClass>::value);
  public:
   /*!
    * @brief constructs an mjbots control loop based on the options struct. Does not Start the controller.
@@ -66,7 +66,7 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   MjbotsControlLoop(std::vector<std::shared_ptr<kodlab::mjbots::JointMoteus>> joints, const ControlLoopOptions &options);
   /*!
    * @brief constructs an mjbots control loop based on the options struct. Does not Start the controller.
-   * @param robot_in an instance of a derived RobotInterface
+   * @param robot_in an instance of a derived RobotBase
    * @param options contains options defining the behavior
    * \overload 
    */

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -9,7 +9,7 @@
 #include <type_traits>
 #include "kodlab_mjbots_sdk/abstract_realtime_object.h"
 #include "kodlab_mjbots_sdk/robot_interface.h"
-#include "kodlab_mjbots_sdk/mjbots_robot_interface.h"
+#include "kodlab_mjbots_sdk/mjbots_hardware_interface.h"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
 #include "lcm/lcm-cpp.hpp"
 #include "real_time_tools/timer.hpp"
@@ -121,7 +121,7 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   void SetupOptions(const ControlLoopOptions &options);
 
   std::shared_ptr<RobotClass> robot_;     /// ptr to the robot object
-  std::shared_ptr<kodlab::mjbots::MjbotsRobotInterface> mjbots_interface_;   ///ptr to mjbots_interface object, if unique causes issues, also should be initialized inside thread
+  std::shared_ptr<kodlab::mjbots::MjbotsHardwareInterface> mjbots_interface_;   ///ptr to mjbots_interface object, if unique causes issues, also should be initialized inside thread
   int frequency_;                         /// frequency of the controller in Hz
   int num_joints_;                        /// Number of motors
   ControlLoopOptions options_;            /// Options struct
@@ -149,10 +149,10 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
                                           options.soft_start_duration,
                                           options.max_torque);
   
-  mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsRobotInterface>( joint_ptrs,
-                                          options.realtime_params,
-                                          options.imu_mounting_deg,
-                                          options.attitude_rate_hz);
+  mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsHardwareInterface>(joint_ptrs,
+                                                                                options.realtime_params,
+                                                                                options.imu_mounting_deg,
+                                                                                options.attitude_rate_hz);
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }
@@ -163,10 +163,10 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
     lcm_sub_(options.realtime_params.lcm_rtp, options.realtime_params.lcm_cpu, options.input_channel_name) {
   // Create robot object
   robot_ = robot_in;
-  mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsRobotInterface>( robot_->joints,
-                                          options.realtime_params,
-                                          options.imu_mounting_deg,
-                                          options.attitude_rate_hz);
+  mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsHardwareInterface>(robot_->joints,
+                                                                                options.realtime_params,
+                                                                                options.imu_mounting_deg,
+                                                                                options.attitude_rate_hz);
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -41,7 +41,7 @@ struct ControlLoopOptions {
 
 /*!
  * @brief mjbots_control_loop class is an parent class to be used to create a control loop. It supports 1 controller and
- *        logging. The child class must implement CalcTorques and PrepareLog (if logging). The robot data is stored in
+ *        logging. The child class must implement Update and PrepareLog (if logging). The robot data is stored in
  *        the robot object. The behavior runs in its own thread. To Start the thread Run Start()
  * @tparam LogClass[optional] data type for logging
  * @tparam InputClass[optional] class for input data 
@@ -82,7 +82,7 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   /*!
    * @brief function to be implemented by child. Must set torques in the robot class
    */
-  virtual void CalcTorques() {robot_->Update();}
+  virtual void Update() {robot_->Update();}
 
   /*!
    * @brief adds data to m_log_data if logging is being used. To be implemented by child class
@@ -249,7 +249,7 @@ void MjbotsControlLoop<log_type, input_type, robot_type>::Run() {
     }
 
     // Calculate torques and log
-    CalcTorques();      //TODO should we give full control to the robot_ instead of feeding update thorugh?
+    Update();      //TODO should we give full control to the robot_ instead of feeding update thorugh?
     // robot_->Update();
     PrepareLog();
     AddTimingLog(time_now_, sleep_duration, prev_msg_duration);

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -123,7 +123,7 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   std::shared_ptr<RobotClass> robot_;     /// ptr to the robot object
   std::shared_ptr<kodlab::mjbots::MjbotsRobotInterface> mjbots_interface_;   ///ptr to mjbots_interface object, if unique causes issues, also should be initialized inside thread
   int frequency_;                         /// frequency of the controller in Hz
-  int num_motors_;                        /// Number of motors
+  int num_joints_;                        /// Number of motors
   ControlLoopOptions options_;            /// Options struct
   bool logging_ = false;                  /// Boolean to determine if logging is in use
   bool input_ = false;                    /// Boolean to determine if input is in use
@@ -153,7 +153,7 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
                                           options.realtime_params,
                                           options.imu_mounting_deg,
                                           options.attitude_rate_hz);
-  num_motors_ = robot_->joints.size();
+  num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }
 
@@ -167,7 +167,7 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
                                           options.realtime_params,
                                           options.imu_mounting_deg,
                                           options.attitude_rate_hz);
-  num_motors_ = robot_->joints.size();
+  num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }
 

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -82,7 +82,7 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   /*!
    * @brief function to be implemented by child. Must set torques in the robot class
    */
-  virtual void Update() {robot_->Update();}
+  virtual void Update() = 0;
 
   /*!
    * @brief adds data to m_log_data if logging is being used. To be implemented by child class

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -40,9 +40,12 @@ struct ControlLoopOptions {
 };
 
 /*!
- * @brief mjbots_control_loop class is an parent class to be used to create a control loop. It supports 1 controller and
- *        logging. The child class must implement Update and PrepareLog (if logging). The robot data is stored in
- *        the robot object. The behavior runs in its own thread. To Start the thread Run Start()
+ * @brief A parent class used to create a control loop. It supports one
+ *        controller, a `RobotBase` child class, logging, and inputs. The
+ *        `MjbotsControlLoop` child class must implement `Update`,
+ *        `PrepareLog` if logging, and `ProcessInput` if receiving inputs. The
+ *        robot data is stored in the `RobotClass` object. The behavior runs in
+ *        its own thread. To Start the thread, run `Start()`.
  * @tparam LogClass[optional] data type for logging
  * @tparam InputClass[optional] class for input data 
  * @tparam RobotClass[optional] RobotInterfaceDerived class that contains state and control calculations 

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -32,8 +32,8 @@ struct RealtimeParams {
 };
 
 /*!
- * @brief A class that allows interaction with the Mjbots Moteus Motor Controllers
- * 
+ * @brief Object allowing interaction with the Mjbots Moteus motor controller
+ *        hardware
  */
 class MjbotsHardwareInterface  {
  public:

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -35,18 +35,18 @@ struct RealtimeParams {
  * @brief A class that allows interaction with the Mjbots Moteus Motor Controllers
  * 
  */
-class MjbotsRobotInterface  {
+class MjbotsHardwareInterface  {
  public:
 
   /*!
    * @brief constructs an mjbots_robot_interface to communicate with a collection of moeteusses
-   * @param joint_list a list of shared pointers to joints defining the motors in the robot
+   * @param joint_list a vector of shared pointers to joints defining the motors in the robot
    * @param realtime_params the realtime parameters defining cpu and realtime priority
    * @param imu_mounting_deg Orientation of the imu on the pi3hat. Assumes gravity points in the +z direction
    * @param imu_rate_hz Frequency of the imu updates from the pi3hat
    * @param imu_world_offset_deg IMU orientation offset. Useful for re-orienting gravity, etc.
    */
-  MjbotsRobotInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
+  MjbotsHardwareInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
                        const RealtimeParams &realtime_params,
                        ::mjbots::pi3hat::Euler imu_mounting_deg = ::mjbots::pi3hat::Euler(),
                        int imu_rate_hz = 1000,

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -1,7 +1,7 @@
 /*!
- * @file robot_interface.h
+ * @file robot_base.h
  * @author Kodlab - J. Diego Caporale (jdcap@seas.upenn.edu)
- * @brief Robot Interface Class 
+ * @brief Robot Base Class
  * @date 2022-07-12
  * 
  * @copyright Copyright (c) 2021 The Trustees of the University of Pennsylvania. All Rights Reserved
@@ -19,10 +19,10 @@
 namespace kodlab
 {
     /*!
-     * @brief Sets up a kodlab robot interface class 
+     * @brief Sets up a kodlab robot base class
      * 
      */
-    class RobotInterface {
+    class RobotBase {
     public:
         static const int KILL_ROBOT = -1;
         std::vector< std::shared_ptr<JointBase> > joints; ///the vector of shared_ptrs to joints 
@@ -35,10 +35,10 @@ namespace kodlab
          * @param robot_max_torque the maximum torque to allow per motor in the robot
          */
         template <class JointDerived = JointBase>
-        RobotInterface( std::vector<std::shared_ptr<JointDerived>> joint_vect, 
-                        float robot_max_torque,
-                        int soft_start_duration )
-                        : soft_start_(robot_max_torque, soft_start_duration)
+        RobotBase(std::vector<std::shared_ptr<JointDerived>> joint_vect,
+                  float robot_max_torque,
+                  int soft_start_duration)
+            : soft_start_(robot_max_torque, soft_start_duration)
         {
             // Ensure at compile time that the template is JointBase or a child of JointBase
             static_assert(std::is_base_of<JointBase, JointDerived>::value);
@@ -58,7 +58,7 @@ namespace kodlab
         /*!
          * @brief Destroy the Robot Interface object. Virtual destructor for proper derived pointer destruction.
          */
-        virtual ~RobotInterface() {};
+        virtual ~RobotBase() {};
 
         /*!
          * @brief Initialize the robot (e.g. communication or states etc.)

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -56,7 +56,8 @@ namespace kodlab
         }
 
         /*!
-         * @brief Destroy the Robot Interface object. Virtual destructor for proper derived pointer destruction.
+         * @brief Destroy the robot base object. Virtual destructor for proper
+         *        derived pointer destruction.
          */
         virtual ~RobotBase() {};
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/rotations.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/imu_data.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/log.h"
-                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/robot_interface.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/robot_base.h"
         )
 
 set(SOURCE_LIST "pi3hat.cpp" 
@@ -26,7 +26,7 @@ set(SOURCE_LIST "pi3hat.cpp"
                 "polar_leg.cpp"
                 "soft_start.cpp"
                 "abstract_realtime_object.cpp"
-                "robot_interface.cpp"
+                "robot_base.cpp"
                 "joint_base.cpp"
                 "cartesian_leg.cpp"
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,7 @@
 set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3hat.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/moteus_protocol.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3hat_moteus_interface.h"
-                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/mjbots_robot_interface.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/common_header.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/polar_leg.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/cartesian_leg.h"
@@ -21,8 +21,8 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/robot_interface.h"
         )
 
-set(SOURCE_LIST "pi3hat.cpp"
-                "mjbots_robot_interface.cpp"
+set(SOURCE_LIST "pi3hat.cpp" 
+                "mjbots_hardware_interface.cpp"
                 "polar_leg.cpp"
                 "soft_start.cpp"
                 "abstract_realtime_object.cpp"

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -1,25 +1,25 @@
 /*!
- * @file robot_interface.cpp
+ * @file robot_base.cpp
  * @author Kodlab - J. Diego Caporale (jdcap@seas.upenn.edu)
- * @brief Robot Interface Class 
+ * @brief Robot Base Class
  * @date 2022-07-12
  * 
  * @copyright Copyright (c) 2022
  * 
  */
-#include "kodlab_mjbots_sdk/robot_interface.h"
+#include "kodlab_mjbots_sdk/robot_base.h"
 
-std::vector<float> kodlab::RobotInterface::GetJointPositions() { //Copy of positions
+std::vector<float> kodlab::RobotBase::GetJointPositions() { //Copy of positions
   std::vector<float>pos(positions_.begin(), positions_.end());
   return pos;
 }
 
-std::vector<float> kodlab::RobotInterface::GetJointVelocities() { //Copy of velocities
+std::vector<float> kodlab::RobotBase::GetJointVelocities() { //Copy of velocities
   std::vector<float>vel(velocities_.begin(), velocities_.end());
   return vel;
 }
 
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotInterface::GetJoints(std::vector<int> joint_indices){
+std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::vector<int> joint_indices){
   std::vector<std::shared_ptr<JointBase>> joint_list;
   for (int ind: joint_indices){
     joint_list.emplace_back(joints[ind]);
@@ -27,22 +27,23 @@ std::vector<std::shared_ptr<JointBase>> kodlab::RobotInterface::GetJoints(std::v
   return joint_list;
 }
 
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotInterface::GetJoints(std::initializer_list<int> joint_indices){
+std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::initializer_list<int> joint_indices){
   std::vector<int> joint_vect (joint_indices); 
-  return kodlab::RobotInterface::GetJoints(joint_vect);
+  return kodlab::RobotBase::GetJoints(joint_vect);
 }
 
 template <size_t N>
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotInterface::GetJoints(std::array<int,N> joint_indices){
+std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::array<int, N> joint_indices){
   std::vector<int> joint_vect (joint_indices.begin(), joint_indices.end()); 
-  return kodlab::RobotInterface::GetJoints(joint_vect);
+  return kodlab::RobotBase::GetJoints(joint_vect);
 }
 
-std::vector<float> kodlab::RobotInterface::GetJointTorqueCmd() { //Cop of torque_cmds
+std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Cop of torque_cmds
   std::vector<float>torques(torque_cmd_.begin(), torque_cmd_.end());
   return torques;
 }
-void kodlab::RobotInterface::SetTorques(std::vector<float> torques) {
+
+void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
   soft_start_.ConstrainTorques(torques, cycle_count_);
   float torque_cmd;
   for (int joint_ind = 0; joint_ind < num_joints_; joint_ind++) {


### PR DESCRIPTION
Several of the functions and members have outdated names, this updates them to better match their intent.

`MjbotsContolLoop::CalcTorques`  becomes   `MjbotsContolLoop::Update`
`MjbotsContolLoop::num_motors_`  becomes   `MjbotsContolLoop::num_joints_`
`MjbotsContolLoop::Update`  is converted to a pure virtual function
`MJBotsRobotInterface` becomes `MJBotsHardwareInterface`
`RobotInterface` becomes `RobotBase`

