### PR TITLE
Behavior manager class

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ class MyController : public MjbotsControlLoop<LcmLog, LcmInput, MyRobot>
 Refer to `include/examples/simple_robot.h` for a sample robot class and 
 `examples/robot_example.cpp` for a usage example.
 
+## Behavior Manager
+The `BehaviorManager` class is a container for storing and running 
+`Behavior`-derived behaviors.  This class maintains a default behavior at the 
+beginning index in its internal vector. Additional behaviors can be appended to
+the vector and the default behavior can be set by the user. The 
+`BehaviorManager` can be composed into a child class of `MjbotsControlLoop` 
+and used to maintain a series of behaviors running on a`RobotBase`-derived 
+robot. 
+
 ## Soft Start
 To configure the soft Start, set the `options.max_torque` and `options.soft_start_duration`. Where the
 max torque is the maximum torque per motor and the soft Start duration is how long the torque ramp should last

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -120,7 +120,7 @@ public:
       {
         behaviors_[next_idx_]->Init();
       }
-      behaviors_[selected_idx]->Stop(behaviors_[next_idx_]); // stop current behavior
+      behaviors_[selected_idx]->Stop(*behaviors_[next_idx_]); // stop current behavior
       switching_behaviors_ = true;  // indicate transition is in progress
     } else
     {
@@ -220,10 +220,10 @@ public:
   {
     behaviors_[selected_idx]->Update();
     if (switching_behaviors_
-        && behaviors_[selected_idx]->ReadyToSwitch(behaviors_[next_idx_]))
+        && behaviors_[selected_idx]->ReadyToSwitch(*behaviors_[next_idx_]))
     {
       behaviors_[selected_idx]->set_inactive();  // mark previous behavior as inactive
-      behaviors_[next_idx_]->Begin(behaviors_[selected_idx]);  // begin new behavior
+      behaviors_[next_idx_]->Begin(*behaviors_[selected_idx]);  // begin new behavior
       behaviors_[next_idx_]->set_active();  // mark new behavior as active
       selected_idx = next_idx_;  // update selected behavior to next
       switching_behaviors_ = false;  // no longer transitioning behaviors

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -218,7 +218,9 @@ public:
    */
   virtual void Update()
   {
+    behaviors_[selected_idx]->ProcessInput();
     behaviors_[selected_idx]->Update();
+    behaviors_[selected_idx]->ProcessOutput();
     if (switching_behaviors_
         && behaviors_[selected_idx]->ReadyToSwitch(*behaviors_[next_idx_]))
     {

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -1,0 +1,159 @@
+/**
+ * @file behavior_manager.h
+ * @author Ethan J. Musser (emusser@seas.upenn.edu)
+ * @brief Container for managing the `Behaviors` available to a robot and
+ *        switching between them
+ * @date 7/26/22
+ * 
+ * @copyright Copyright 2022 The Trustees of the University of Pennsylvania. All
+ *            rights reserved.
+ * 
+ */
+
+#pragma once
+
+#include <iostream>
+#include <memory>
+#include "kodlab_mjbots_sdk/robot_base.h"
+#include "kodlab_mjbots_sdk/behavior.h"
+#include "kodlab_mjbots_sdk/off_behavior.h"
+#include "kodlab_mjbots_sdk/log.h"
+
+namespace kodlab
+{
+
+/**
+ * @brief Manager for `Behavior` objects
+ * @details The behavior manager class is a container for storing numerous
+ *          behaviors for a given robot interface. It manages their selection
+ *          and transitions between them.
+ * @note By default, this class initializes its internal behaviors list with a
+ *       `kodlab::Offbehavior`. This is done for safety purposes so that, when
+ *       turned on, the robot does not command some undefined torques. This
+ *       default can be overwritten with the `SetDefaultBehavior` member.
+ * @tparam Robot[optional] derived `kodlab::RobotBase` class
+ */
+template<class Robot = kodlab::RobotBase>
+class BehaviorManager
+{
+  static_assert(std::is_base_of<kodlab::RobotBase, Robot>::value,
+                "Robot must have base kodlab::RobotBase.");
+
+private:
+  /**
+   * @brief Robot that behaviors run on
+   */
+  std::shared_ptr<Robot> robot_;
+
+  /**
+   * @brief Behavior command that kills robot, default -1
+   */
+  static const int KILL_ROBOT_IDX = -1;
+
+  /**
+   * @brief Behaviors available to the robot
+   * @note The first element of this vector is always `OFF_BEHAVIOR`.  Added
+   *       behaviors are appended to the end.
+   */
+  std::vector<std::unique_ptr<Behavior<Robot>>> behaviors_;
+
+  /**
+   * @brief Names of behaviors in `behaviors_`
+   */
+  std::vector<std::string> names_;
+
+  /**
+   * @brief Index in `behaviors_` of the selected behavior
+   */
+  unsigned int selected_idx = 0;
+
+  /**
+   * @brief Index in `behaviors_` of the incoming behavior while transitioning
+   *        behaviors
+   */
+  int next_idx_ = 0;
+
+  /**
+   * @brief Indicates whether a behavior switch is in progress
+   */
+  bool switching_behaviors_ = false;
+
+public:
+  /**
+   * @brief Construct a behavior manager object
+   * @param robot pointer to robot that the behavior is executing on
+   */
+  BehaviorManager(std::shared_ptr<Robot> robot) : robot_(robot) {}
+
+  /**
+   * @brief Destructor
+   */
+  virtual ~BehaviorManager() {}
+
+  /**
+   * @brief Set the current behavior
+   * @param next_idx index in `behaviors_`
+   */
+  virtual void SetBehavior(const int &next_idx);
+
+  /**
+   * @brief Add a behavior to the behaviors list and initialize it
+   * @tparam BehaviorType `kodlab::Behavior`-derived type
+   * @tparam ConstructorArgs constructor arguments
+   * @param args behavior constructor arguments
+   */
+  template<class BehaviorType, typename... ConstructorArgs>
+  void AddBehavior(ConstructorArgs &&... args);
+
+  /**
+   * @brief Reset the behaviors list back to default
+   */
+  void ResetBehaviors();
+
+  /**
+   * @brief Update the current behavior
+   * @param robot shared pointer to robot behavior is executing on
+   */
+  virtual void Update();
+
+  /**
+   * @brief Accessor for index of selected behavior
+   * @return selected behavior index
+   */
+  [[nodiscard]] unsigned int get_selected_behavior() const
+  {
+    return selected_idx;
+  }
+
+  /**
+   * @brief Accessor for names of behaviors in `behaviors_`
+   * @param behavior_idx index of behavior
+   * @return name of behavior at index `behavior_idx` in `behaviors_`
+   */
+  [[nodiscard]] std::string get_behavior_name(int behavior_idx) const
+  {
+    return behaviors_[behavior_idx]->get_name();
+  }
+
+  /**
+   * @brief Accessor for name of selected behavior
+   * @return selected behavior name
+   */
+  [[nodiscard]] std::string get_sel_behavior_name() const
+  {
+    return get_behavior_name(selected_idx);
+  }
+
+  /**
+   * @brief Accessor for all behavior names in `behaviors_`
+   * @return vector of names of behaviors
+   */
+  [[nodiscard]] std::vector<std::string> get_behavior_list() const
+  {
+    return names_;
+  }
+
+};
+
+} // kodlab
+

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -218,7 +218,7 @@ public:
    */
   virtual void Update()
   {
-    behaviors_[selected_idx]->ProcessInput();
+    behaviors_[selected_idx]->ThreadSafeProcessInput();
     behaviors_[selected_idx]->Update();
     behaviors_[selected_idx]->ProcessOutput();
     if (switching_behaviors_

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -14,6 +14,7 @@
 
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <utility>
 #include "kodlab_mjbots_sdk/robot_base.h"
@@ -163,11 +164,9 @@ class BehaviorManager {
     if (name == KILL_BEHAVIOR_NAME) { SetBehavior(KILL_ROBOT_IDX); }
     else {
       auto idx = get_behavior_index(name);
-      if (idx >= 0) { SetBehavior(idx); }
+      if (idx) { SetBehavior(idx.value()); }
       else {
-        LOG_WARN("Invalid behavior selected: %s at index %d",
-                 name.c_str(),
-                 idx);
+        LOG_WARN("Invalid behavior selected: %s", name.c_str());
       }
     }
   }
@@ -177,11 +176,11 @@ class BehaviorManager {
    * @tparam BehaviorType `kodlab::Behavior`-derived type
    * @tparam ConstructorArgs constructor arguments
    * @param args behavior constructor arguments
-   * @return index of behavior in behaviors list if added successfully, -1
-   * otherwise
+   * @return index of behavior in behaviors list if added successfully,
+   * `std::nullopt` otherwise
    */
   template<class BehaviorType, typename... ConstructorArgs>
-  int AddBehavior(ConstructorArgs &&... args) {
+  std::optional<int> AddBehavior(ConstructorArgs &&... args) {
     static_assert(std::is_base_of<kodlab::Behavior<Robot>, BehaviorType>::value,
                   "BehaviorType must be a `kodlab::Behavior`-derived type");
     auto b = ConstructBehavior<BehaviorType>(args...);
@@ -196,7 +195,7 @@ class BehaviorManager {
       LOG_WARN(
           "%s behavior could not be initialized and will not be added to behaviors list.",
           b->get_name().c_str());
-      return -1;
+      return {};
     }
   }
 
@@ -296,15 +295,16 @@ class BehaviorManager {
   /**
    * @brief Lookup for behavior index by name
    * @param name behavior name
-   * @return index of behavior if behavior is in the behavior list, -1 otherwise
+   * @return index of behavior if behavior is in the behavior list,
+   * `std::nullopt` otherwise
    */
-  [[nodiscard]] int get_behavior_index(const std::string &name) {
+  [[nodiscard]] std::optional<int> get_behavior_index(const std::string &name) {
     auto it = name_to_idx_map_.find(name);
     if (it != name_to_idx_map_.end()) {
       return it->second;
     } else {
       LOG_WARN("%s is not in behavior list.", name.c_str());
-      return -1;
+      return {};
     }
   }
 

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -145,6 +145,25 @@ public:
   }
 
   /**
+   * @brief Replaces the default behavior with a user-defined one
+   * @note This is included to provide support for custom default robot
+   *       behaviors. If this function is not called, the default behavior will
+   *       be a `kodlab::OffBehavior`.
+   * @tparam BehaviorType `kodlab::Behavior`-derived type
+   * @tparam ConstructorArgs constructor arguments
+   * @param args behavior constructor arguments
+   */
+  template<class BehaviorType, typename... ConstructorArgs>
+  void SetDefaultBehavior(ConstructorArgs &&... args)
+  {
+    static_assert(std::is_base_of<kodlab::Behavior<Robot>, BehaviorType>::value,
+                  "BehaviorType must be a `kodlab::Behavior`-derived type");
+    behaviors_[0] = std::make_unique<BehaviorType>(args...);
+    names_[0] = behaviors_.back()->get_name();
+    behaviors_[0]->Init();
+  }
+
+  /**
    * @brief Reset the behaviors list back to default
    */
   void ResetBehaviors()

--- a/include/kodlab_mjbots_sdk/behavior_manager.h
+++ b/include/kodlab_mjbots_sdk/behavior_manager.h
@@ -179,18 +179,19 @@ public:
 
   /**
    * @brief Prints a list of behaviors currently in `behaviors_`
+   * @param stream output stream
    */
-  void PrintBehaviorList() const
+  void PrintBehaviorList(FILE *stream = stdout) const
   {
-    std::fprintf(stdout, "+--------------------------------+\n");
-    std::fprintf(stdout, "| Control Loop Behaviors         |\n");
-    std::fprintf(stdout, "| ----------------------         |\n");
+    std::fprintf(stream, "+--------------------------------+\n");
+    std::fprintf(stream, "| Control Loop Behaviors         |\n");
+    std::fprintf(stream, "| ----------------------         |\n");
     for (unsigned int i = 0; i < names_.size(); i++)
     {
-      std::fprintf(stdout, "| %3d. %-25s |\n",
+      std::fprintf(stream, "| %3d. %-25s |\n",
                    i, names_[i].c_str());
     }
-    std::fprintf(stdout, "+--------------------------------+\n");
+    std::fprintf(stream, "+--------------------------------+\n");
   }
 
   /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/imu_data.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/log.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/robot_base.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/behavior_manager.h"
         )
 
 set(SOURCE_LIST "pi3hat.cpp" 


### PR DESCRIPTION
An abstract class for implementing `RobotBase`-derived robot behaviors.

- Provides a `BehaviorManager` class in the `kodlab` namespace to maintain one or several `Behavior`-derived behaviors and manage switching between them.
  - `BehaviorManager` is templated for a `RobotBase`-derived robot, as are the behaviors it holds.
  - Stores behaviors internally in a variable-length container and maintains a default behavior at index 0 of this container (by default, this is the `kodlab::OffBehavior`).
  - Provides methods for adding behaviors and switching between them, including waiting to switch until the running behavior is ready.

Note that this PR is 2/3 in the behavior implementation series and depends on the `Behavior` class introduced in #39.

Features to be implemented in future work include:

- Event-based behavior switching.
- Maintaining a timeout behavior that, if the running behavior does not permit switching in within a set period of time, will be switched to.