### PR TITLE
Adds virtual intitialization method to MjbotsControlLoop

### DIFF
--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -78,6 +78,20 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
  protected:
 
   /*!
+   * @brief Initialization function run when the control loop is started
+   * @details This function is called at the beginning of the `Run` function,
+   *          and can be used for initialization in child implementations.
+   * @note This function is called in the `Run` function directly after `robot_`
+   *       and `mjbots_interface_` are initialized.  Any initialization desired
+   *       before this point should be written into the derived class
+   *       constructors.
+   * @note This function is included to provide a user-overridable
+   *       initialization function.  It is not called in the constructor due to
+   *       issues with virtual methods in base class constructors.
+   */
+  virtual void Init() {}
+
+  /*!
    * @brief runs the controller at frequency and logs the data
    */
   void Run() override;
@@ -218,6 +232,7 @@ void MjbotsControlLoop<log_type, input_type, robot_type>::Run() {
 
   mjbots_interface_->Init();
   robot_->Init();
+  Init();
 
   float prev_msg_duration = 0;
 


### PR DESCRIPTION
Adds a virtual intialization function to `MjbotsControlLoop` for initializing members of derived classes.  In its present state, `MjbotsControlLoop`-derivatives must write their own constructors (of which there are several to duplicate from `MjbotsControlLoop`) in order to intialize their members.  This closes #23.