### PR TITLE
Moves JointBase to kodlab namespace (closes #25)

### DIFF
--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -16,6 +16,8 @@
 #include <type_traits>
 #include <string>
 
+namespace kodlab
+{
 
 /**
  * Abstract joint state class with torque and joint pose limiting capabilities.
@@ -253,3 +255,5 @@ public:
      */
     joint_type & operator[](size_t i) {return *(v_[i]);}
 };
+
+} // kodlab

--- a/src/joint_base.cpp
+++ b/src/joint_base.cpp
@@ -11,6 +11,9 @@
 #include <iostream>
 #include "kodlab_mjbots_sdk/joint_base.h"
 
+namespace kodlab
+{
+
 JointBase::JointBase(std::string name,
                      int direction,
                      float zero_offset,
@@ -69,4 +72,4 @@ void JointBase::UpdateState(float servo_pos, float servo_vel){
     velocity_= direction_ * servo_vel / gear_ratio_ ;
 }
 
-
+} // kodlab

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -19,21 +19,21 @@ std::vector<float> kodlab::RobotBase::GetJointVelocities() { //Copy of velocitie
   return vel;
 }
 
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::vector<int> joint_indices){
-  std::vector<std::shared_ptr<JointBase>> joint_list;
+std::vector<std::shared_ptr<kodlab::JointBase>> kodlab::RobotBase::GetJoints(std::vector<int> joint_indices){
+  std::vector<std::shared_ptr<kodlab::JointBase>> joint_list;
   for (int ind: joint_indices){
     joint_list.emplace_back(joints[ind]);
   }
   return joint_list;
 }
 
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::initializer_list<int> joint_indices){
+std::vector<std::shared_ptr<kodlab::JointBase>> kodlab::RobotBase::GetJoints(std::initializer_list<int> joint_indices){
   std::vector<int> joint_vect (joint_indices); 
   return kodlab::RobotBase::GetJoints(joint_vect);
 }
 
 template <size_t N>
-std::vector<std::shared_ptr<JointBase>> kodlab::RobotBase::GetJoints(std::array<int, N> joint_indices){
+std::vector<std::shared_ptr<kodlab::JointBase>> kodlab::RobotBase::GetJoints(std::array<int, N> joint_indices){
   std::vector<int> joint_vect (joint_indices.begin(), joint_indices.end()); 
   return kodlab::RobotBase::GetJoints(joint_vect);
 }


### PR DESCRIPTION
Moves the `JointBase` class (and associated `JointSharedVector` class) to the `kodlab` namespace.  Currently they are in the top-level namespace.  Closes #25.