### PR TITLE
Moves examples to kodlab::examples namespace

### DIFF
--- a/examples/imu_example.cpp
+++ b/examples/imu_example.cpp
@@ -15,6 +15,9 @@
 #include "kodlab_mjbots_sdk/imu_data.h"
 #include "IMULog.hpp"
 
+namespace kodlab::examples
+{
+
 class AttitudeExample : public kodlab::mjbots::MjbotsControlLoop<IMULog,
                                                                  VoidLcm>
 {
@@ -92,6 +95,9 @@ private:
 
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv)
 {
   // Setup Joints
@@ -119,6 +125,7 @@ int main(int argc, char **argv)
   options.imu_world_offset_deg.yaw = 0;
 
   // Create Control Loop
+  using kodlab::examples::AttitudeExample;
   AttitudeExample control_loop(joints, options);
 
   // Starts the Loop, Then Joins It

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -15,6 +15,9 @@
 #include "kodlab_mjbots_sdk/cartesian_leg.h"
 #include "kodlab_mjbots_sdk/log.h"  // provides console logging macros
 
+namespace kodlab::examples
+{
+
 class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   using MjbotsControlLoop::MjbotsControlLoop;
 
@@ -152,6 +155,9 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   const float kSoftVelocityThreshold = 0.08;/// Threshold error from 0 in rad/s for terminating soft start
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv) {
   //Setup joints
   std::vector<kodlab::mjbots::JointMoteus> joints;
@@ -165,6 +171,7 @@ int main(int argc, char **argv) {
   options.soft_start_duration = 5000;
 
   // Create control loop
+  using kodlab::examples::Hopping;
   Hopping control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -18,6 +18,9 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
+namespace kodlab::examples
+{
+
 class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
   void Update() override {
@@ -57,6 +60,9 @@ class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv) {
 
   //Setup joints
@@ -74,6 +80,7 @@ int main(int argc, char **argv) {
   options.parallelize_control_loop = true; 
 
   // Create control loop
+  using kodlab::examples::Joints3DoF;
   Joints3DoF control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -18,6 +18,9 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
+namespace kodlab::examples
+{
+
 class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
   void Update() override {
@@ -75,6 +78,9 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv) {
 
   //Setup joints
@@ -90,6 +96,7 @@ int main(int argc, char **argv) {
   options.realtime_params.can_cpu  = 2;
   
   // Create control loop
+  using kodlab::examples::ProprioJoints;
   ProprioJoints control_loop(std::move(joints), options);
 
   // Starts the loop, and then join it

--- a/examples/robot_example.cpp
+++ b/examples/robot_example.cpp
@@ -19,6 +19,9 @@
 
 #include "examples/simple_robot.h"
 
+namespace kodlab::examples
+{
+
 class SimpleRobotControlLoop : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog, ModeInput, SimpleRobot>
 {
     using MjbotsControlLoop::MjbotsControlLoop;
@@ -57,6 +60,9 @@ class SimpleRobotControlLoop : public kodlab::mjbots::MjbotsControlLoop<ManyMoto
     }
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv)
 {
     // Setup joints with a std::vector or JointSharedVector class
@@ -76,6 +82,7 @@ int main(int argc, char **argv)
 
     // Create control loop
     // Starts the loop, and then join it
+    using kodlab::examples::SimpleRobotControlLoop;
     SimpleRobotControlLoop simple_robot(joints, options);
     simple_robot.Start();
     simple_robot.Join();

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -16,6 +16,9 @@
 #include <Eigen/Core>
 #include <Eigen/Dense>
 
+namespace kodlab::examples
+{
+
 class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   using MjbotsControlLoop::MjbotsControlLoop;
   void Update() override {
@@ -39,6 +42,9 @@ class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 };
 
+} // kodlab::examples
+
+
 int main(int argc, char **argv) {
   //Setup joints
   std::vector<kodlab::mjbots::JointMoteus> joints;
@@ -60,6 +66,7 @@ int main(int argc, char **argv) {
 
   // Create control loop
   LOG_INFO("Constructing Spin_Joint with %zu joints.", joints.size());
+  using kodlab::examples::Spin_Joint;
   Spin_Joint control_loop(std::move(joints), options);
   // Starts the loop, and then join it
   control_loop.Start();


### PR DESCRIPTION
Currently examples clutter the top-level namespace.  This PR moves all the current SDK examples to the `kodlab::examples` namespace.  Closes #32.