### PR TITLE
adds IMUData member to RobotBase

### DIFF
--- a/include/examples/simple_robot.h
+++ b/include/examples/simple_robot.h
@@ -29,7 +29,7 @@ public:
     void Update() override {
         std::vector<float> torques(num_joints_, 0);
         // Get states you want to use.
-        auto& imu_data = GetIMUData();
+        const auto& imu_data = GetIMUData();
         auto pos = GetJointPositions();
         auto vel = GetJointVelocities();
 

--- a/include/examples/simple_robot.h
+++ b/include/examples/simple_robot.h
@@ -1,8 +1,8 @@
 /**
  * @file simple_robot.h
  * @author J. Diego Caporale
- * @brief A simple RobotBase derived class example. Here is where you would implement any state updates,
- *        behaviors, or control system
+ * @brief A simple RobotBase derived class example. An example of where you 
+ *        would implement any state updates, behaviors, or control system.
  * @date 2022-07-19
  *
  * @copyright Copyright (c) 2022
@@ -13,6 +13,11 @@
 
 #include "kodlab_mjbots_sdk/robot_base.h"
 
+/**
+ * @brief Simple Robot class, updates state variables and sets torques to zero.
+ * @note Setting torque is not necessarily something that should be done in
+ *       a robot class this example just shows that it can be
+ */
 class SimpleRobot : virtual public kodlab::RobotBase
 {
 
@@ -21,9 +26,13 @@ class SimpleRobot : virtual public kodlab::RobotBase
 public:
     int mode = 0; // Member variables encode whatever added state we need
     // Set up robot update function for state and torques
-    void Update() override
-    {
+    void Update() override {
         std::vector<float> torques(num_joints_, 0);
+        // Get states you want to use.
+        auto& imu_data = GetIMUData();
+        auto pos = GetJointPositions();
+        auto vel = GetJointVelocities();
+
         SetTorques(torques);
     }
 };

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -173,14 +173,17 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
 {
   lcm_sub_->AddSubscription<input_type>(options.input_channel_name, input_sub_);
 
-  robot_ = std::make_shared<robot_type>(  joint_ptrs,
-                                          options.soft_start_duration,
-                                          options.max_torque);
-  
   mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsHardwareInterface>(joint_ptrs,
                                                                                 options.realtime_params,
                                                                                 options.imu_mounting_deg,
-                                                                                options.attitude_rate_hz);
+                                                                                options.attitude_rate_hz, 
+                                                                                options.imu_world_offset_deg);
+
+  robot_ = std::make_shared<robot_type>(  joint_ptrs,
+                                          options.soft_start_duration,
+                                          options.max_torque,
+                                          mjbots_interface_->GetIMUDataSharedPtr());
+
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }
@@ -197,7 +200,8 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
   mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsHardwareInterface>(robot_->joints,
                                                                                 options.realtime_params,
                                                                                 options.imu_mounting_deg,
-                                                                                options.attitude_rate_hz);
+                                                                                options.imu_world_offset_deg,
+                                                                                robot_->GetIMUDataSharedPtr());
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -50,7 +50,8 @@ class MjbotsHardwareInterface  {
                        const RealtimeParams &realtime_params,
                        ::mjbots::pi3hat::Euler imu_mounting_deg = ::mjbots::pi3hat::Euler(),
                        int imu_rate_hz = 1000,
-                       ::mjbots::pi3hat::Euler imu_world_offset_deg = ::mjbots::pi3hat::Euler());
+                       ::mjbots::pi3hat::Euler imu_world_offset_deg = ::mjbots::pi3hat::Euler(),
+                       std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr);
 
   /**
    * @brief Send and recieve initial communications effectively starting the robot
@@ -103,7 +104,14 @@ class MjbotsHardwareInterface  {
    * @brief accessor for the IMU data of the robot
    * @return const IMU data shared pointer for the robot
    */
-  const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr();
+  const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr();        
+  
+  /*!
+  * @brief Setter for the robot's IMU data pointer. Releases the previously owned IMU data object
+  *
+  * @param imu_data_ptr a shared pointer to kodlab::IMUData
+  */
+  void SetIMUDataSharedPtr(std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr){imu_data_ = imu_data_ptr;}
 
  private:
   std::vector< std::shared_ptr<JointMoteus>> joints; /// Vector of shared pointers to joints for the robot, shares state information

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <future>
 #include <memory>
+#include <optional>
 #include "kodlab_mjbots_sdk/moteus_protocol.h"
 #include "kodlab_mjbots_sdk/joint_moteus.h"
 #include "kodlab_mjbots_sdk/pi3hat_moteus_interface.h"
@@ -44,14 +45,16 @@ class MjbotsHardwareInterface  {
    * @param realtime_params the realtime parameters defining cpu and realtime priority
    * @param imu_mounting_deg Orientation of the imu on the pi3hat. Assumes gravity points in the +z direction
    * @param imu_rate_hz Frequency of the imu updates from the pi3hat
-   * @param imu_world_offset_deg IMU orientation offset. Useful for re-orienting gravity, etc.
+   * @param imu_data_ptr Shared pointer to imu_data to use or nullptr if it should make its own
+   * @param imu_world_offset_deg [Optional] IMU orientation offset. Useful for re-orienting gravity, etc.
    */
   MjbotsHardwareInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
                        const RealtimeParams &realtime_params,
                        ::mjbots::pi3hat::Euler imu_mounting_deg = ::mjbots::pi3hat::Euler(),
                        int imu_rate_hz = 1000,
-                       ::mjbots::pi3hat::Euler imu_world_offset_deg = ::mjbots::pi3hat::Euler(),
-                       std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr);
+                       std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr,
+                       std::optional<::mjbots::pi3hat::Euler > imu_world_offset_deg = std::nullopt
+                       );
 
   /**
    * @brief Send and recieve initial communications effectively starting the robot

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -115,18 +115,17 @@ namespace kodlab
          */
         std::vector<float> GetJointTorqueCmd();
 
-        
         /*!
         * @brief accessor for the IMU data of the robot
         * @return const reference to the IMU data object for the robot
         */
-        const ::kodlab::IMUData<float>& GetIMUData();
+        const ::kodlab::IMUData<float>& GetIMUData(){return *imu_data_;}
 
         /*!
         * @brief accessor for the IMU data of the robot
         * @return const IMU data shared pointer for the robot
         */
-        const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr();  
+        const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr(){return imu_data_;}
 
         /*!
         * @brief Setter for the robot's IMU data pointer. Releases the previously owned IMU data object

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -15,6 +15,7 @@
 #include "kodlab_mjbots_sdk/common_header.h"
 #include "kodlab_mjbots_sdk/joint_base.h"
 #include "kodlab_mjbots_sdk/soft_start.h"
+#include "kodlab_mjbots_sdk/imu_data.h"
 
 namespace kodlab
 {
@@ -37,7 +38,8 @@ namespace kodlab
         template <class JointDerived = JointBase>
         RobotBase(std::vector<std::shared_ptr<JointDerived>> joint_vect,
                   float robot_max_torque,
-                  int soft_start_duration)
+                  int soft_start_duration,
+                  std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr)
             : soft_start_(robot_max_torque, soft_start_duration)
         {
             // Ensure at compile time that the template is JointBase or a child of JointBase
@@ -53,6 +55,16 @@ namespace kodlab
 
             // Set number of joints
             num_joints_ = joint_vect.size();
+            
+            // Initialize attitude shared pointer
+            if (imu_data_ptr)
+            {
+                imu_data_ = imu_data_ptr;
+            }
+            else
+            {
+                imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
+            }
         }
 
         /*!
@@ -103,7 +115,25 @@ namespace kodlab
          */
         std::vector<float> GetJointTorqueCmd();
 
-        //TODO virtual Attitude GetAttitude()
+        
+        /*!
+        * @brief accessor for the IMU data of the robot
+        * @return const reference to the IMU data object for the robot
+        */
+        const ::kodlab::IMUData<float>& GetIMUData();
+
+        /*!
+        * @brief accessor for the IMU data of the robot
+        * @return const IMU data shared pointer for the robot
+        */
+        const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr();  
+
+        /*!
+        * @brief Setter for the robot's IMU data pointer. Releases the previously owned IMU data object
+        *
+        * @param imu_data_ptr a shared pointer to kodlab::IMUData
+        */
+        void SetIMUDataSharedPtr(std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr){imu_data_ = imu_data_ptr;}
 
         /*! 
          * @brief Get sub-vector of shared_ptr to joint objects via a set of indices
@@ -139,7 +169,7 @@ namespace kodlab
         std::vector<std::reference_wrapper<const float>> positions_;  /// Vector of the motor positions (references to the members of joints_)
         std::vector<std::reference_wrapper<const float>> velocities_; /// Vector of the motor velocities (references to the members of joints_)
         std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)
-        //TODO Attitude attitude_; 
+        std::shared_ptr<::kodlab::IMUData<float>> imu_data_;          /// Robot IMU data
         SoftStart soft_start_;                                        /// Soft Start object
         int num_joints_ = 0;                                          /// Number of joints
     };

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -58,12 +58,10 @@ namespace kodlab
             num_joints_ = joint_vect.size();
             
             // Initialize attitude shared pointer
-            if (imu_data_ptr)
-            {
+            if (imu_data_ptr) {
                 imu_data_ = imu_data_ptr;
             }
-            else
-            {
+            else {
                 imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
             }
         }

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -34,6 +34,7 @@ namespace kodlab
          * @param joint_vect a vector of shared pointers to jointbase defining the motors in the robot
          * @param soft_start_duration how long in dt to spend ramping the torque
          * @param robot_max_torque the maximum torque to allow per motor in the robot
+         * @param imu_data_ptr [Optional] Shared pointer to imu_data to use or nullptr if robot should make its own
          */
         template <class JointDerived = JointBase>
         RobotBase(std::vector<std::shared_ptr<JointDerived>> joint_vect,

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -51,7 +51,8 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
                                                  const RealtimeParams &realtime_params,
                                                  ::mjbots::pi3hat::Euler imu_mounting_deg,
                                                  int imu_rate_hz,
-                                                 ::mjbots::pi3hat::Euler imu_world_offset_deg) 
+                                                 ::mjbots::pi3hat::Euler imu_world_offset_deg,
+                                                 std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr) 
 { 
   joints = joint_ptrs;
   num_joints_ = joints.size();
@@ -73,7 +74,13 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
   moteus_interface_ = std::make_shared<::mjbots::moteus::Pi3HatMoteusInterface>(moteus_options);
 
   // Initialize attitude shared pointer
-  imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
+  if(imu_data_ptr){
+    imu_data_ = imu_data_ptr;
+  }
+  else
+  {
+    imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
+  }
   kodlab::rotations::EulerAngles<float> imu_world_offset =
       {M_PI / 180.0 * imu_world_offset_deg.roll,
        M_PI / 180.0 * imu_world_offset_deg.pitch,

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -51,8 +51,9 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
                                                  const RealtimeParams &realtime_params,
                                                  ::mjbots::pi3hat::Euler imu_mounting_deg,
                                                  int imu_rate_hz,
-                                                 ::mjbots::pi3hat::Euler imu_world_offset_deg,
-                                                 std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr) 
+                                                 std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr,
+                                                 std::optional<::mjbots::pi3hat::Euler> imu_world_offset_deg) 
+    : imu_data_(imu_data_ptr ? imu_data_ptr : std::make_shared<::kodlab::IMUData<float>>())
 { 
   joints = joint_ptrs;
   num_joints_ = joints.size();
@@ -73,18 +74,14 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
   moteus_options.imu_mounting_deg = imu_mounting_deg;
   moteus_interface_ = std::make_shared<::mjbots::moteus::Pi3HatMoteusInterface>(moteus_options);
 
-  // Initialize attitude shared pointer
-  if(imu_data_ptr){
-    imu_data_ = imu_data_ptr;
+  if(imu_world_offset_deg.has_value()){
+    kodlab::rotations::EulerAngles<float> imu_world_offset = {
+        static_cast<float>(M_PI / 180.0 * imu_world_offset_deg->roll),
+        static_cast<float>(M_PI / 180.0 * imu_world_offset_deg->pitch),
+        static_cast<float>(M_PI / 180.0 * imu_world_offset_deg->yaw)
+        };
+    imu_data_->set_world_offset(imu_world_offset.ToQuaternion());
   }
-  else{
-    imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
-  }
-  kodlab::rotations::EulerAngles<float> imu_world_offset =
-      {M_PI / 180.0 * imu_world_offset_deg.roll,
-       M_PI / 180.0 * imu_world_offset_deg.pitch,
-       M_PI / 180.0 * imu_world_offset_deg.yaw};
-  imu_data_->set_world_offset(imu_world_offset.ToQuaternion());
 
   // Initialize and send basic command
   InitializeCommand();

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -77,8 +77,7 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
   if(imu_data_ptr){
     imu_data_ = imu_data_ptr;
   }
-  else
-  {
+  else{
     imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
   }
   kodlab::rotations::EulerAngles<float> imu_world_offset =

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -50,12 +50,3 @@ void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
     torque_cmd = joints[joint_ind]->UpdateTorque(torques[joint_ind]);
   }
 }
-
-const ::kodlab::IMUData<float>& kodlab::RobotBase::GetIMUData() {
-  return *imu_data_;
-}
-
-const std::shared_ptr<::kodlab::IMUData<float>> kodlab::RobotBase::GetIMUDataSharedPtr() {
-  return imu_data_;
-}
-

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -51,3 +51,11 @@ void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
   }
 }
 
+const ::kodlab::IMUData<float>& kodlab::RobotBase::GetIMUData() {
+  return *imu_data_;
+}
+
+const std::shared_ptr<::kodlab::IMUData<float>> kodlab::RobotBase::GetIMUDataSharedPtr() {
+  return imu_data_;
+}
+

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -50,3 +50,4 @@ void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
     torque_cmd = joints[joint_ind]->UpdateTorque(torques[joint_ind]);
   }
 }
+


### PR DESCRIPTION
the IMUData is currently another shared pointer between the two classes, this can make construction a bit clunky, since we are not passing in the attitude class from ControlLoop. Instead now RobotBase and MJbotsHardwareInterface both take an IMUData shared_ptr as an optional argument in the constructor. 

The shared joints are more intuitive because they are passed in by the user to ControlLoop who then passes them along (by design) where attitude is not passed in by user. 

May want to change the interaction between the two or remove one of the constructors so openning up this PR for discussion.