### PR TITLE
Lcm publisher

### DIFF
--- a/examples/imu_example.cpp
+++ b/examples/imu_example.cpp
@@ -64,30 +64,30 @@ private:
   }
 
   /**
-   * @brief Prepares log
+   * @brief Populates log message with data from current control loop cycle
    */
   void PrepareLog() override
   {
     // IMUData Quaternion
-    log_data_.attitude_quaternion[0] = imu_->get_quat().x();
-    log_data_.attitude_quaternion[1] = imu_->get_quat().y();
-    log_data_.attitude_quaternion[2] = imu_->get_quat().z();
-    log_data_.attitude_quaternion[3] = imu_->get_quat().w();
+    log_data_->attitude_quaternion[0] = imu_->get_quat().x();
+    log_data_->attitude_quaternion[1] = imu_->get_quat().y();
+    log_data_->attitude_quaternion[2] = imu_->get_quat().z();
+    log_data_->attitude_quaternion[3] = imu_->get_quat().w();
 
     // IMUData Euler Angles
-    log_data_.attitude_euler[0] = imu_->get_euler().roll();
-    log_data_.attitude_euler[1] = imu_->get_euler().pitch();
-    log_data_.attitude_euler[2] = imu_->get_euler().yaw();
+    log_data_->attitude_euler[0] = imu_->get_euler().roll();
+    log_data_->attitude_euler[1] = imu_->get_euler().pitch();
+    log_data_->attitude_euler[2] = imu_->get_euler().yaw();
 
     // Angular Velocity
-    log_data_.angular_velocity[0] = imu_->get_ang_rate().x();
-    log_data_.angular_velocity[1] = imu_->get_ang_rate().y();
-    log_data_.angular_velocity[2] = imu_->get_ang_rate().z();
+    log_data_->angular_velocity[0] = imu_->get_ang_rate().x();
+    log_data_->angular_velocity[1] = imu_->get_ang_rate().y();
+    log_data_->angular_velocity[2] = imu_->get_ang_rate().z();
 
     // Linear Acceleration
-    log_data_.linear_acceleration[0] = imu_->get_accel().x();
-    log_data_.linear_acceleration[1] = imu_->get_accel().y();
-    log_data_.linear_acceleration[2] = imu_->get_accel().z();
+    log_data_->linear_acceleration[0] = imu_->get_accel().x();
+    log_data_->linear_acceleration[1] = imu_->get_accel().y();
+    log_data_->linear_acceleration[2] = imu_->get_accel().z();
   }
 
 };

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -85,19 +85,20 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
   }
 
   void PrepareLog() override {
+    // Populate log message with data from current control loop cycle
     for (int servo = 0; servo < 2; servo++) {
-      log_data_.positions[servo] = robot_->GetJointPositions()[servo];
-      log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
-      log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
-      log_data_.torque_cmd[servo] = robot_->GetJointTorqueCmd()[servo];
+      log_data_->positions[servo] = robot_->GetJointPositions()[servo];
+      log_data_->velocities[servo] = robot_->GetJointVelocities()[servo];
+      log_data_->modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
+      log_data_->torque_cmd[servo] = robot_->GetJointTorqueCmd()[servo];
     }
-    log_data_.limb_position[0] = z_ - z0_;
-    log_data_.limb_position[1] = x_;
-    log_data_.limb_vel[0] = d_z_;
-    log_data_.limb_vel[1] = d_x_;
-    log_data_.limb_wrench[0] = f_z_;
-    log_data_.limb_wrench[1] = f_x_;
-    log_data_.hybrid_mode = mode_;
+    log_data_->limb_position[0] = z_ - z0_;
+    log_data_->limb_position[1] = x_;
+    log_data_->limb_vel[0] = d_z_;
+    log_data_->limb_vel[1] = d_x_;
+    log_data_->limb_wrench[0] = f_z_;
+    log_data_->limb_wrench[1] = f_x_;
+    log_data_->hybrid_mode = mode_;
   }
 
   void ProcessInput() override {

--- a/examples/leg_3DoF_example.cpp
+++ b/examples/leg_3DoF_example.cpp
@@ -42,17 +42,20 @@ class Joints3DoF : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 
   void PrepareLog() override {
+    // Populate log message with data from current control loop cycle
     for (int servo = 0; servo < num_joints_; servo++) {
-      log_data_.positions[servo]  = robot_->GetJointPositions()[servo];
-      log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
-      log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
-      log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
+      log_data_->positions[servo]  = robot_->GetJointPositions()[servo];
+      log_data_->velocities[servo] = robot_->GetJointVelocities()[servo];
+      log_data_->modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
+      log_data_->torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
+
+    // Fill remaining log message fields with zeros
     for (int servo = num_joints_; servo < 13; servo++) {
-      log_data_.positions[servo] = 0;
-      log_data_.velocities[servo] = 0;
-      log_data_.modes[servo] = 0;
-      log_data_.torques[servo] = 0;
+      log_data_->positions[servo] = 0;
+      log_data_->velocities[servo] = 0;
+      log_data_->modes[servo] = 0;
+      log_data_->torques[servo] = 0;
     }
   }
 };

--- a/examples/proprio_example.cpp
+++ b/examples/proprio_example.cpp
@@ -60,17 +60,20 @@ class ProprioJoints : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 
   void PrepareLog() override {
+    // Populate log message with data from current control loop cycle
     for (int servo = 0; servo < num_joints_; servo++) {
-      log_data_.positions[servo]  = robot_->GetJointPositions()[servo];
-      log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
-      log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
-      log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
+      log_data_->positions[servo]  = robot_->GetJointPositions()[servo];
+      log_data_->velocities[servo] = robot_->GetJointVelocities()[servo];
+      log_data_->modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
+      log_data_->torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
+
+    // Fill remaining log message fields with zeros
     for (int servo = num_joints_; servo < 13; servo++) {
-      log_data_.positions[servo] = 0;
-      log_data_.velocities[servo] = 0;
-      log_data_.modes[servo] = 0;
-      log_data_.torques[servo] = 0;
+      log_data_->positions[servo] = 0;
+      log_data_->velocities[servo] = 0;
+      log_data_->modes[servo] = 0;
+      log_data_->torques[servo] = 0;
     }
   }
 };

--- a/examples/robot_example.cpp
+++ b/examples/robot_example.cpp
@@ -29,19 +29,22 @@ class SimpleRobotControlLoop : public kodlab::mjbots::MjbotsControlLoop<ManyMoto
     }
     void PrepareLog() override
     {
+        // Populate log message with data from current control loop cycle
         for (int servo = 0; servo < num_joints_; servo++)
         {
-            log_data_.positions[servo] = robot_->GetJointPositions()[servo];
-            log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
-            log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
-            log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
+            log_data_->positions[servo] = robot_->GetJointPositions()[servo];
+            log_data_->velocities[servo] = robot_->GetJointVelocities()[servo];
+            log_data_->modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
+            log_data_->torques[servo] = robot_->GetJointTorqueCmd()[servo];
         }
+
+        // Fill remaining log message fields with zeros
         for (int servo = num_joints_; servo < 13; servo++)
         {
-            log_data_.positions[servo] = 0;
-            log_data_.velocities[servo] = 0;
-            log_data_.modes[servo] = 0;
-            log_data_.torques[servo] = 0;
+            log_data_->positions[servo] = 0;
+            log_data_->velocities[servo] = 0;
+            log_data_->modes[servo] = 0;
+            log_data_->torques[servo] = 0;
         }
     }
 

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -24,17 +24,20 @@ class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
   }
 
   void PrepareLog() override {
+    // Populate log message with data from current control loop cycle
     for (int servo = 0; servo < num_joints_; servo++) {
-      log_data_.positions[servo] = robot_->GetJointPositions()[servo];
-      log_data_.velocities[servo] = robot_->GetJointVelocities()[servo];
-      log_data_.modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
-      log_data_.torques[servo] = robot_->GetJointTorqueCmd()[servo];
+      log_data_->positions[servo] = robot_->GetJointPositions()[servo];
+      log_data_->velocities[servo] = robot_->GetJointVelocities()[servo];
+      log_data_->modes[servo] = static_cast<int>(mjbots_interface_->GetJointModes()[servo]);
+      log_data_->torques[servo] = robot_->GetJointTorqueCmd()[servo];
     }
+
+    // Fill remaining log message fields with zeros
     for (int servo = num_joints_; servo < 13; servo++) {
-      log_data_.positions[servo] = 0;
-      log_data_.velocities[servo] = 0;
-      log_data_.modes[servo] = 0;
-      log_data_.torques[servo] = 0;
+      log_data_->positions[servo] = 0;
+      log_data_->velocities[servo] = 0;
+      log_data_->modes[servo] = 0;
+      log_data_->torques[servo] = 0;
     }
   }
 };

--- a/include/kodlab_mjbots_sdk/lcm_publisher.h
+++ b/include/kodlab_mjbots_sdk/lcm_publisher.h
@@ -1,0 +1,139 @@
+/**
+ * @file lcm_publisher.h
+ * @author Ethan J. Musser (emusser@seas.upenn.edu)
+ * @brief Provides `LcmPublisher` class which handles storage and publishing of
+ * LCM messages.
+ * @date 8/7/22
+ * 
+ * @copyright (c) Copyright 2022 The Trustees of the University of Pennsylvania.
+ * All rights reserved.
+ * 
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "lcm/lcm-cpp.hpp"
+
+namespace kodlab {
+
+/**
+ * @brief LCM message data container and publisher
+ * @note One way to use the `lcm::LCM` object is to have a single object which
+ * publishes multiple messages on multiple channels. To support this usage, the
+ * internal `lcm::LCM` object is stored as a shared pointer, which is set during
+ * construction and accessible later on. this pointer can be passed around and
+ * used in multiple `LcmPublisher` objects.
+ * @tparam Message LCM message type
+ */
+template<class Message>
+class LcmPublisher {
+
+ public:
+
+  /**
+   * @brief Construct an LCM publisher object without an `lcm::LCM` object or
+   * channel.
+   */
+  LcmPublisher() = default;
+
+  /**
+   * @brief Construct an LCM publisher object with a shared LCM object.
+   * @param lcm `lcm::LCM` object shared pointer
+   * @param channel channel name for publishing
+   */
+  LcmPublisher(std::shared_ptr<lcm::LCM> lcm, const std::string &channel)
+      : lcm_(lcm), channel_(channel), message_(std::make_shared<Message>()) {}
+
+  /**
+   * @brief Construct an LCM publisher object with an owned LCM object.
+   * @param lcm `lcm::LCM` object rvalue (must transfer ownership)
+   * @param channel channel name for publishing
+   */
+  LcmPublisher(lcm::LCM &&lcm, const std::string &channel)
+      : LcmPublisher(std::make_shared<lcm::LCM>(std::move(lcm)), channel) {}
+
+  /**
+   * @brief Publish the data stored in `message_` on LCM channel `channel_`.
+   */
+  void Publish() {
+    lcm_->publish<Message>(channel_, message_.get());
+  }
+
+  /**
+   * @brief Retrieve shared pointer to the LCM object used for publishing.
+   * @return shared pointer to `lcm::LCM` object
+   */
+  [[nodiscard]] std::shared_ptr<lcm::LCM> get_lcm() const { return lcm_; }
+
+  /**
+   * @brief Set the object used for publishing as a new, shared LCM object.
+   * @param lcm shared pointer to `lcm::LCM` object
+   */
+  void set_lcm(std::shared_ptr<lcm::LCM> lcm) { lcm_ = lcm; }
+
+  /**
+   * @brief Set the object used for publishing as a new, owned LCM object.
+   * @param lcm `lcm::LCM` object rvalue (must transfer ownership)
+   */
+  void set_lcm(lcm::LCM &&lcm) {
+    lcm_ = std::make_shared<lcm::LCM>(std::move(lcm));
+  }
+
+  /**
+   * @brief Retrieve the LCM publishing channel name.
+   * @return name of LCM channel used for publishing
+   */
+  [[nodiscard]] const std::string get_channel() const { return channel_; }
+
+  /**
+   * @brief Set the LCM channel used for publishing.
+   * @param channel name of LCM channel to be used for publishing
+   */
+  void set_channel(const std::string &channel) { channel_ = channel; }
+
+  /**
+   * @brief Retrieve a shared pointer to the internally stored message data.
+   * @return shared pointer to internal message data
+   */
+  [[nodiscard]] const std::shared_ptr<Message> get_message_shared_ptr() const {
+    return message_;
+  }
+
+  /**
+   * @brief Retrieve a raw pointer to the internally stored message data.
+   * @return raw pointer to internal message data
+   */
+  [[nodiscard]] const Message *get_message_ptr() const {
+    return message_.get();
+  }
+
+  /**
+   * @brief Retrieve read-only version of internally stored message data.
+   * @return read-only copy of internal message data
+   */
+  [[nodiscard]] const Message get_message_data() const { return *message_; }
+
+ private:
+
+  /**
+   * @brief LCM object used for publishing.
+   * @note This object can be shared by multiple `LcmPublishers`.
+   */
+  std::shared_ptr<lcm::LCM> lcm_;
+
+  /**
+   * @brief LCM publishing channel name.
+   */
+  std::string channel_;
+
+  /**
+   * @brief Internal message that is published on calls to `Publish`.
+   */
+  std::shared_ptr<Message> message_;
+
+};
+
+} // kodlab

--- a/include/kodlab_mjbots_sdk/lcm_publisher.h
+++ b/include/kodlab_mjbots_sdk/lcm_publisher.h
@@ -45,7 +45,7 @@ class LcmPublisher {
    * @param channel channel name for publishing
    */
   LcmPublisher(std::shared_ptr<lcm::LCM> lcm, const std::string &channel)
-      : lcm_(lcm), channel_(channel), message_(std::make_shared<Message>()) {}
+      : lcm_(lcm), channel_(channel) {}
 
   /**
    * @brief Construct an LCM publisher object with an owned LCM object.
@@ -132,7 +132,7 @@ class LcmPublisher {
   /**
    * @brief Internal message that is published on calls to `Publish`.
    */
-  std::shared_ptr<Message> message_;
+  std::shared_ptr<Message> message_ = std::make_shared<Message>();
 
 };
 

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -11,6 +11,7 @@
 #include "kodlab_mjbots_sdk/robot_base.h"
 #include "kodlab_mjbots_sdk/mjbots_hardware_interface.h"
 #include "kodlab_mjbots_sdk/lcm_subscriber.h"
+#include "kodlab_mjbots_sdk/lcm_publisher.h"
 #include "lcm/lcm-cpp.hpp"
 #include "real_time_tools/timer.hpp"
 #include "real_time_tools/hard_spinner.hpp"
@@ -145,8 +146,9 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
   bool logging_ = false;                  /// Boolean to determine if logging is in use
   bool input_ = false;                    /// Boolean to determine if input is in use
   std::string logging_channel_name_;      /// Channel name to publish logs to, leave empty if not publishing
-  lcm::LCM lcm_;                          /// LCM object
-  LogClass log_data_;                     /// object containing log data
+  std::shared_ptr<lcm::LCM> lcm_;         /// LCM object shared pointer
+  LcmPublisher<LogClass> log_pub_;        /// log LCM publisher
+  std::shared_ptr<LogClass> log_data_;    /// LCM log message data shared pointer
   LcmSubscriber<InputClass> lcm_sub_;     /// LCM subscriber object
   float time_now_ = 0;                    /// Time since start in micro seconds
 };
@@ -160,6 +162,9 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vector<std::shared_ptr<kodlab::mjbots::JointMoteus>> joint_ptrs, const ControlLoopOptions &options)
   : AbstractRealtimeObject(options.realtime_params.main_rtp, options.realtime_params.can_cpu),
+    lcm_(std::make_shared<lcm::LCM>()),
+    log_pub_(lcm_, options.log_channel_name),
+    log_data_(log_pub_.get_message_shared_ptr()),
     lcm_sub_(options.realtime_params.lcm_rtp, options.realtime_params.lcm_cpu, options.input_channel_name) 
 {
   robot_ = std::make_shared<robot_type>(  joint_ptrs,
@@ -177,6 +182,9 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shared_ptr<robot_type>robot_in, const ControlLoopOptions &options)
   : AbstractRealtimeObject(options.realtime_params.main_rtp, options.realtime_params.can_cpu),
+    lcm_(std::make_shared<lcm::LCM>()),
+    log_pub_(lcm_, options.log_channel_name),
+    log_data_(log_pub_.get_message_shared_ptr()),
     lcm_sub_(options.realtime_params.lcm_rtp, options.realtime_params.lcm_cpu, options.input_channel_name) {
   // Create robot object
   robot_ = robot_in;
@@ -214,16 +222,16 @@ void MjbotsControlLoop<log_type, input_type, robot_type>::SetupOptions(const Con
 template<class log_type, class input_type, class robot_type>
 void MjbotsControlLoop<log_type, input_type, robot_type>::AddTimingLog(float t, float margin, float message_duration) {
   if (logging_) {
-    log_data_.timestamp = t;
-    log_data_.margin = margin;
-    log_data_.message_duration = message_duration;
+    log_data_->timestamp = t;
+    log_data_->margin = margin;
+    log_data_->message_duration = message_duration;
   }
 }
 
 template<class log_type, class input_type, class robot_type>
 void MjbotsControlLoop<log_type, input_type, robot_type>::PublishLog() {
   if (logging_)
-    lcm_.publish(logging_channel_name_, &log_data_);
+    log_pub_.Publish();
 }
 
 template<class log_type, class input_type, class robot_type>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/cartesian_leg.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/soft_start.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/lcm_subscriber.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/lcm_publisher.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/abstract_realtime_object.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/mjbots_control_loop.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_base.h"


### PR DESCRIPTION
Provide `LcmPublisher` object to handle storage and publishing of LCM messages.  This object makes it easy to publish to multiple LCM channels via one or multiple `lcm::LCM` objects, and handle storage of this information.

- Provides `LcmPublisher` object
- Replaces usage of `lcm::LCM` object in `MjbotsControlLoop` with `LcmPublisher` object.
- Updates `MjbotsControlLoop`-derived control loop to use new logging structure.
