### PR TITLE
Add channel selection to mode_input_cli.py

### DIFF
--- a/python_scripts/mode_input_cli.py
+++ b/python_scripts/mode_input_cli.py
@@ -22,6 +22,7 @@ Copyright:
 import lcm
 from lcm_types.ModeInput import ModeInput
 import warnings
+import argparse
 
 # Ignore deprecation warnings from ``lcm`` dependencies
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -29,10 +30,22 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 # Constants
 OFF = 0  # OFF behavior integer
 KILL = -1  # KILL behavior integer
-LCM_CHANNEL = "mode_input"  # must match channel name in control loop options
+DEFAULT_LCM_CHANNEL = "mode_input"
 
 
-def publish_mode(mode, print_msg="", lcm_ch=LCM_CHANNEL):
+def parse_channel():
+    """
+    """
+    # Parse input arguments
+    parser = argparse.ArgumentParser(
+        description='publish mode input messages via LCM.')
+    parser.add_argument('channel', metavar='channel', type=str, nargs='+',
+                        help='LCM channel name to publish on')
+    args = parser.parse_args()
+    return args.channel[0]
+
+
+def publish_mode(mode, print_msg="", lcm_ch=DEFAULT_LCM_CHANNEL):
     """
     Publish an LCM ``ModeInput`` message with mode value ``mode`` on channel
     ``ch``.  Prints ``print_msg`` to console, if provided.
@@ -60,22 +73,26 @@ def header_str(kill_int):
 
 
 def main():
+    # Parse input
+    channel = parse_channel()
+
     try:
         # Print header
         print(header_str(OFF))
+        print(f"Publishing to channel \"{channel}\"")
 
         # Initially set mode to be ``OFF``
         mode = OFF
-        publish_mode(mode)
+        publish_mode(mode, lcm_ch=channel)
 
         # Repeatedly prompt for mode input
         while True:
             mode = input(f'Enter mode:  ')
             try:
-                publish_mode(int(mode))
+                publish_mode(int(mode), lcm_ch=channel)
             except ValueError:
                 if mode.upper() == 'Q':
-                    publish_mode(OFF, 'Exiting.')
+                    publish_mode(OFF, 'Exiting.', lcm_ch=channel)
                     break
                 else:
                     print('Invalid input.')
@@ -83,8 +100,8 @@ def main():
                 print('Invalid input.')
     except KeyboardInterrupt:
         print('Keyboard interrupt.  Killing Robot and exiting.')
-        for _ in range(5): # ensure KILL message is received
-            publish_mode(KILL)
+        for _ in range(5):  # ensure KILL message is received
+            publish_mode(KILL, lcm_ch=channel)
 
 
 if __name__ == '__main__':

--- a/python_scripts/mode_input_cli.py
+++ b/python_scripts/mode_input_cli.py
@@ -33,16 +33,14 @@ KILL = -1  # KILL behavior integer
 DEFAULT_LCM_CHANNEL = "mode_input"
 
 
-def parse_channel():
-    """
-    """
-    # Parse input arguments
+def parse_args():
+    """Parse input arguments"""
     parser = argparse.ArgumentParser(
         description='publish mode input messages via LCM.')
     parser.add_argument('channel', metavar='channel', type=str, nargs='+',
                         help='LCM channel name to publish on')
     args = parser.parse_args()
-    return args.channel[0]
+    return args
 
 
 def publish_mode(mode, print_msg="", lcm_ch=DEFAULT_LCM_CHANNEL):
@@ -74,7 +72,7 @@ def header_str(kill_int):
 
 def main():
     # Parse input
-    channel = parse_channel()
+    channel = parse_args().channel[0]
 
     try:
         # Print header
@@ -83,7 +81,6 @@ def main():
 
         # Initially set mode to be ``OFF``
         mode = OFF
-        publish_mode(mode, lcm_ch=channel)
 
         # Repeatedly prompt for mode input
         while True:


### PR DESCRIPTION
Simple change permitting channel selection when running the sample `mode_input_cli.py` script for sending mode inputs.  The script should now be called by
```bash
python3 mode_input_cli.py <channel_name>
```