### PR TITLE
Add timer and fix soft start construction parameter order bug in robot

### DIFF
--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -163,7 +163,7 @@ int main(int argc, char **argv) {
   kodlab::mjbots::ControlLoopOptions options;
   options.log_channel_name = "leg_data";
   options.input_channel_name = "leg_gains";
-  options.soft_start_duration = 5000;
+  options.soft_start_duration_ms = 5000;
 
   // Create control loop
   Hopping control_loop(std::move(joints), options);

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -28,7 +28,7 @@ struct ControlLoopOptions {
   RealtimeParams realtime_params;  /// Set of parameters for robot's realtimeness
 
   float max_torque = 20;             /// Maximum torque in Nm
-  int soft_start_duration = 1000;    /// Duration of the soft Start in cycles
+  float soft_start_duration_ms = 1000;    /// Duration of the soft Start in ms
   int frequency = 1000;              /// Frequency of the control loop in Hz
   std::string log_channel_name;         /// LCM channel name for logging data. Leave empty to not log
   std::string input_channel_name;       /// LCM channel name for input data. Leave empty to not use input
@@ -166,7 +166,7 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(
     std::vector<std::shared_ptr<kodlab::mjbots::JointMoteus>> joint_ptrs, const ControlLoopOptions &options)
-  : MjbotsControlLoop(std::make_shared<robot_type>(joint_ptrs,options.soft_start_duration, options.max_torque),options) {}
+  : MjbotsControlLoop(std::make_shared<robot_type>(joint_ptrs, options.max_torque, options.soft_start_duration_ms),options) {}
 
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shared_ptr<robot_type>robot_in, const ControlLoopOptions &options)

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -82,7 +82,7 @@ namespace kodlab
          * @warning All derivative classes overriding this method should include
          *          a cycle count increment (i.e., `cycle_count_++;`).
          */
-        virtual void Update(){}; //TODO remove cycle_count and use time or more intelligently set cycle_count or properly handle softstart
+        virtual void Update(){};
 
         /*!
          * @brief Stop the robot by setting torques to zero. Can be overridden

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -27,21 +27,20 @@ namespace kodlab
     public:
         static const int KILL_ROBOT = -1;  // Kill mode/behavior index; used to signal robot E-stop
         std::vector< std::shared_ptr<JointBase> > joints; ///the vector of shared_ptrs to joints 
-        u_int64_t cycle_count_; //TODO Make this time based not cycle based for when the system fails to keep up (i.e. time_us_)
         
         /*!
          * @brief constructs a robot_interface that contains the basic state of a jointed robot with attitude
          * @param joint_vect a vector of shared pointers to jointbase defining the motors in the robot
-         * @param soft_start_duration how long in dt to spend ramping the torque
+         * @param soft_start_duration_ms how long in ms to spend ramping the torque
          * @param robot_max_torque the maximum torque to allow per motor in the robot
          * @param imu_data_ptr [Optional] Shared pointer to imu_data to use or nullptr if robot should make its own
          */
         template <class JointDerived = JointBase>
         RobotBase(std::vector<std::shared_ptr<JointDerived>> joint_vect,
                   float robot_max_torque,
-                  int soft_start_duration,
+                  float soft_start_duration_ms,
                   std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr)
-            : soft_start_(robot_max_torque, soft_start_duration)
+            : soft_start_(robot_max_torque, soft_start_duration_ms)
         {
             // Ensure at compile time that the template is JointBase or a child of JointBase
             static_assert(std::is_base_of<JointBase, JointDerived>::value);
@@ -64,6 +63,7 @@ namespace kodlab
             else {
                 imu_data_ = std::make_shared<::kodlab::IMUData<float>>();
             }
+            run_timer_.tic(); // Start timer
         }
 
         /*!
@@ -82,7 +82,7 @@ namespace kodlab
          * @warning All derivative classes overriding this method should include
          *          a cycle count increment (i.e., `cycle_count_++;`).
          */
-        virtual void Update(){cycle_count_++;}; //TODO remove cycle_count and use time or more intelligently set cycle_count or properly handle softstart
+        virtual void Update(){}; //TODO remove cycle_count and use time or more intelligently set cycle_count or properly handle softstart
 
         /*!
          * @brief Stop the robot by setting torques to zero. Can be overridden
@@ -168,6 +168,7 @@ namespace kodlab
         std::vector<std::reference_wrapper<const float>> velocities_; /// Vector of the motor velocities (references to the members of joints_)
         std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)
         std::shared_ptr<::kodlab::IMUData<float>> imu_data_;          /// Robot IMU data
+        real_time_tools::Timer run_timer_;                            /// Run timer for robot, started at construction
         SoftStart soft_start_;                                        /// Soft Start object
         int num_joints_ = 0;                                          /// Number of joints
     };

--- a/include/kodlab_mjbots_sdk/soft_start.h
+++ b/include/kodlab_mjbots_sdk/soft_start.h
@@ -2,6 +2,7 @@
 // Copyright (c) 2021 The Trustees of the University of Pennsylvania. All Rights Reserved
 // Authors:
 // Shane Rozen-Levy <srozen01@seas.upenn.edu>
+// J. Diego Caporale <jdcap@seas.upenn.edu>
 
 
 #pragma once
@@ -16,14 +17,15 @@ class SoftStart {
  private:
   float slope_ = 0;        /// Slope of the ramp
   float max_torque_ = 100; /// Max torque allowed in Nm
-  float duration_ms_ = 0;   /// Duration of soft Start in steps
+  float duration_ms_ = 0;   /// Duration of soft start in milliseconds
 
  public:
 
   /*!
    * @brief constrains the vector torques based on soft Start
    * @param torques[in, out] the torques to be constrained
-   * @param count the number of steps it has been
+   * @param time_since_start_ms the number of milliseconds it has been since
+   * start
    */
   void ConstrainTorques(std::vector<float> &torques, float time_since_start_ms);
 

--- a/include/kodlab_mjbots_sdk/soft_start.h
+++ b/include/kodlab_mjbots_sdk/soft_start.h
@@ -16,7 +16,7 @@ class SoftStart {
  private:
   float slope_ = 0;        /// Slope of the ramp
   float max_torque_ = 100; /// Max torque allowed in Nm
-  int duration_ = 0;       /// Duration of soft Start in steps
+  float duration_ms_ = 0;   /// Duration of soft Start in steps
 
  public:
 
@@ -25,7 +25,7 @@ class SoftStart {
    * @param torques[in, out] the torques to be constrained
    * @param count the number of steps it has been
    */
-  void ConstrainTorques(std::vector<float> &torques, int count);
+  void ConstrainTorques(std::vector<float> &torques, float time_since_start_ms);
 
   /*!
    * @brief constrains all values in values between min_val and max_val
@@ -47,8 +47,8 @@ class SoftStart {
   /*!
    * @brief constructor for soft Start
    * @param max_torque maximum torque allowed in robot
-   * @param duration how long for ramp to last in steps
+   * @param duration_ms how long for ramp to last in ms
    */
-  SoftStart(float max_torque, int duration);
+  SoftStart(float max_torque, float duration_ms);
 };
 } // namespace kodlab

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -44,7 +44,7 @@ std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Cop of torque_cmds
 }
 
 void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
-  soft_start_.ConstrainTorques(torques, cycle_count_);
+  soft_start_.ConstrainTorques(torques, run_timer_.tac()/1000.0);
   float torque_cmd;
   for (int joint_ind = 0; joint_ind < num_joints_; joint_ind++) {
     torque_cmd = joints[joint_ind]->UpdateTorque(torques[joint_ind]);

--- a/src/soft_start.cpp
+++ b/src/soft_start.cpp
@@ -17,16 +17,15 @@ float SoftStart::Constrain(float values, float min_val, float max_val) {
   return fmin(fmax(values, min_val), max_val);
 }
 
-void SoftStart::ConstrainTorques(std::vector<float> &torques, int count) {
-  if (count > duration_) {
+void SoftStart::ConstrainTorques(std::vector<float> &torques, float time_since_start_ms) {
+  if ((time_since_start_ms) > duration_ms_) { // ramp_timer returns in us
     Constrain(torques, -max_torque_, max_torque_);
   } else {
-    float max_val = count * slope_;
+    float max_val = (time_since_start_ms) * slope_;
     Constrain(torques, -max_val, max_val);
-
   }
 
 }
-SoftStart::SoftStart(float max_torque, int duration)
-    : max_torque_(fabs(max_torque)), duration_(duration), slope_(fabs(max_torque) / (fmax(duration, 1))) {}
+SoftStart::SoftStart(float max_torque, float duration_ms)
+    : max_torque_(fabs(max_torque)), duration_ms_(duration_ms), slope_(fabs(max_torque) / (fmax(duration_ms, 1.0))) {}
 } // namespace kodlab

--- a/src/soft_start.cpp
+++ b/src/soft_start.cpp
@@ -2,12 +2,16 @@
 // Copyright (c) 2021 The Trustees of the University of Pennsylvania. All Rights Reserved
 // Authors:
 // Shane Rozen-Levy <srozen01@seas.upenn.edu>
+// J. Diego Caporale <jdcap@seas.upenn.edu>
 
 
 #include "kodlab_mjbots_sdk/soft_start.h"
 
 namespace kodlab {
-void SoftStart::Constrain(std::vector<float> &values, float min_val, float max_val) {
+
+void SoftStart::Constrain(std::vector<float> &values,
+                          float min_val,
+                          float max_val) {
   for (auto &value : values) {
     value = fmin(fmax(value, min_val), max_val);
   }
@@ -17,15 +21,20 @@ float SoftStart::Constrain(float values, float min_val, float max_val) {
   return fmin(fmax(values, min_val), max_val);
 }
 
-void SoftStart::ConstrainTorques(std::vector<float> &torques, float time_since_start_ms) {
-  if ((time_since_start_ms) > duration_ms_) { // ramp_timer returns in us
+void SoftStart::ConstrainTorques(std::vector<float> &torques,
+                                 float time_since_start_ms) {
+  if (time_since_start_ms > duration_ms_) {
     Constrain(torques, -max_torque_, max_torque_);
   } else {
-    float max_val = (time_since_start_ms) * slope_;
+    float max_val = time_since_start_ms * slope_;
     Constrain(torques, -max_val, max_val);
   }
 
 }
+
 SoftStart::SoftStart(float max_torque, float duration_ms)
-    : max_torque_(fabs(max_torque)), duration_ms_(duration_ms), slope_(fabs(max_torque) / (fmax(duration_ms, 1.0))) {}
-} // namespace kodlab
+    : max_torque_(fabs(max_torque)),
+      duration_ms_(duration_ms),
+      slope_(fabs(max_torque) / (fmax(duration_ms, 1.0))) {}
+
+} // kodlab


### PR DESCRIPTION
This commit adds a realtime timer to remove the cycle_count that measure update
loops and fixes a construction bug where torque and duration were flipped.
In the case that the cycle time overflowed the intended frequency the
cycle count is no longer meaningful and gives the user little understanding of
the time past. A timer is agnostic to a misbehaving update cycle.