### PR TITLE
Implement dry run capability

### DIFF
--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -40,6 +40,7 @@ struct ControlLoopOptions {
   ::mjbots::pi3hat::Euler imu_world_offset_deg; /// IMU orientation offset. Useful for re-orienting gravity, etc.
   int attitude_rate_hz = 1000;              /// Frequency of the imu updates from the pi3hat. Options are limited to 1000
                                             /// 400, 200, 100.
+  bool dry_run = false;  ///< If true, torques will be printed to console and not sent to the joints
 };
 
 /*!
@@ -188,7 +189,8 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
   mjbots_interface_ = std::make_shared<kodlab::mjbots::MjbotsHardwareInterface>(
       std::move(joints_moteus), options.realtime_params,
       options.imu_mounting_deg, options.attitude_rate_hz,
-      robot_->GetIMUDataSharedPtr(), options.imu_world_offset_deg);
+      robot_->GetIMUDataSharedPtr(), options.imu_world_offset_deg,
+      options.dry_run);
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -40,7 +40,8 @@ struct ControlLoopOptions {
   ::mjbots::pi3hat::Euler imu_world_offset_deg; /// IMU orientation offset. Useful for re-orienting gravity, etc.
   int attitude_rate_hz = 1000;              /// Frequency of the imu updates from the pi3hat. Options are limited to 1000
                                             /// 400, 200, 100.
-  bool dry_run = false;  ///< If true, torques will be printed to console and not sent to the joints
+  bool dry_run = false;  ///< If true, torques sent to moteus boards will always be zero
+  bool print_torques = false;  ///< If true, torque commandss will be printed to console
 };
 
 /*!
@@ -190,7 +191,8 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
       std::move(joints_moteus), options.realtime_params,
       options.imu_mounting_deg, options.attitude_rate_hz,
       robot_->GetIMUDataSharedPtr(), options.imu_world_offset_deg,
-      options.dry_run);
+      options.dry_run,
+      options.print_torques);
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -47,7 +47,8 @@ class MjbotsHardwareInterface  {
    * @param imu_rate_hz Frequency of the imu updates from the pi3hat
    * @param imu_data_ptr Shared pointer to imu_data to use or nullptr if it should make its own
    * @param imu_world_offset_deg [Optional] IMU orientation offset. Useful for re-orienting gravity, etc.
-   * @param dry_run_in prints torque commands and sends zero-torques to Moteus controllers
+   * @param dry_run if true, sends zero-torques to Moteus controllers
+   * @param print_torques if true, prints torque commands
    */
   MjbotsHardwareInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
                        const RealtimeParams &realtime_params,
@@ -55,7 +56,8 @@ class MjbotsHardwareInterface  {
                        int imu_rate_hz = 1000,
                        std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr,
                        std::optional<::mjbots::pi3hat::Euler > imu_world_offset_deg = std::nullopt,
-                       bool dry_run_in = false
+                       bool dry_run = false,
+                       bool print_torques = false
                        );
 
   /**
@@ -123,6 +125,7 @@ class MjbotsHardwareInterface  {
   int num_joints_ = 0;                               /// Number of joints
   u_int64_t cycle_count_ = 0;                        /// Number of cycles/commands sent
   bool dry_run_;                                     ///< dry run active flag
+  bool print_torques_;                               ///< print torques active flag
 
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -47,13 +47,15 @@ class MjbotsHardwareInterface  {
    * @param imu_rate_hz Frequency of the imu updates from the pi3hat
    * @param imu_data_ptr Shared pointer to imu_data to use or nullptr if it should make its own
    * @param imu_world_offset_deg [Optional] IMU orientation offset. Useful for re-orienting gravity, etc.
+   * @param dry_run_in prints torque commands and sends zero-torques to Moteus controllers
    */
   MjbotsHardwareInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
                        const RealtimeParams &realtime_params,
                        ::mjbots::pi3hat::Euler imu_mounting_deg = ::mjbots::pi3hat::Euler(),
                        int imu_rate_hz = 1000,
                        std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr,
-                       std::optional<::mjbots::pi3hat::Euler > imu_world_offset_deg = std::nullopt
+                       std::optional<::mjbots::pi3hat::Euler > imu_world_offset_deg = std::nullopt,
+                       bool dry_run_in = false
                        );
 
   /**
@@ -120,11 +122,12 @@ class MjbotsHardwareInterface  {
   std::vector< std::shared_ptr<JointMoteus>> joints; /// Vector of shared pointers to joints for the robot, shares state information
   int num_joints_ = 0;                               /// Number of joints
   u_int64_t cycle_count_ = 0;                        /// Number of cycles/commands sent
+  bool dry_run_;                                     ///< dry run active flag
 
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 
   std::vector<std::reference_wrapper<const ::mjbots::moteus::Mode>> modes_; /// Vector of current moteus modes (references to the members of joints_)
-  
+
   std::shared_ptr<bool> timeout_ = std::make_shared<bool>(false);                /// True if communication has timed out
 
   std::vector<::mjbots::moteus::Pi3HatMoteusInterface::ServoCommand> commands_;  /// Vector of servo commands

--- a/include/kodlab_mjbots_sdk/string.h
+++ b/include/kodlab_mjbots_sdk/string.h
@@ -1,0 +1,100 @@
+/**
+ * @file string.h
+ * @author Ethan J. Musser (emusser@seas.upenn.edu)
+ * @brief Assorted methods relating to `std::string` objects
+ * @date 8/21/22
+ *
+ * @copyright (c) Copyright 2022 The Trustees of the University of Pennsylvania.
+ * All rights reserved.
+ *
+ */
+
+#pragma once
+
+#include <array>  // std::array
+#include <iomanip>  // std::fixed, std::setw
+#include <string>  // std::string
+#include <sstream>  // std::stringstream
+#include <vector>  // std::vector
+
+#include <Eigen/Core>  // Eigen::MatrixX, Eigen::IOFormat
+
+namespace kodlab::string {
+
+/**
+ * @brief Format a vector of scalars as a string.
+ * @details A convenience function to format a `std::vector` of scalars as a
+ * `std::string`.
+ * @tparam Scalar numeric type
+ * @param vector `std::vector` of scalars
+ * @param precision nuber of digits after the decimal place for floating point
+ * values
+ * @param width allotted number of characters per floating point value
+ * @return `std::string` containing a comma-separated list of the values in
+ * `vector`
+ */
+template<typename Scalar>
+static std::string ScalarVectorToString(const std::vector<Scalar> &vector,
+                                        int precision = 2,
+                                        int width = 8) {
+  std::stringstream ss;
+  ss.precision(precision);
+  ss << std::fixed << "[ ";
+  for (auto it = vector.begin(); it != vector.end(); it++) {
+    if (it != vector.begin()) { ss << ", "; }
+    ss << std::setw(width) << *it;
+  }
+  ss << " ]";
+  return ss.str();
+}
+
+/**
+ * @brief Format an array of scalars as a string.
+ * @details A convenience function to format a `std::array` of scalars as a
+ * `std::string`.
+ * @tparam Scalar numeric type
+ * @tparam N number of array elements
+ * @param array `std::array` of scalarsVector
+ * @param precision nuber of digits after the decimal place for floating point
+ * values
+ * @param width allotted number of characters per floating point value
+ * @return `std::string` containing a comma-separated list of the values in
+ * `array`
+ */
+template<typename Scalar, int N>
+static std::string ScalarArrayToString(const std::array<Scalar, N> &array,
+                                       int precision = 2,
+                                       int width = 8) {
+  std::stringstream ss;
+  ss.precision(precision);
+  ss << std::fixed << "[ ";
+  for (auto it = array.begin(); it != array.end(); it++) {
+    if (it != array.begin()) { ss << ", "; }
+    ss << std::setw(width) << *it;
+  }
+  ss << " ]";
+  return ss.str();
+}
+
+/**
+ * @brief Format an `Eigen::Matrix` of scalars as a string.
+ * @details A convenience function to format an `Eigen::Matrix` of scalars as a
+ * `std::string`.
+ * @tparam Scalar numeric type
+ * @param matrix `std::vector` of
+ * @param precision nuber of digits after the decimal place for floating point
+ * values
+ * @param width maximum number of characters per value
+ * @return `std::string` containing a comma-separated list of the values in
+ * `vector`
+ */
+template<typename Scalar>
+std::string EigenMatrixToString(const Eigen::MatrixX<Scalar> &matrix,
+                                int precision = 2) {
+  Eigen::IOFormat fmt(precision, 0, ", ", "\n", "[ ", " ]");
+  std::stringstream ss;
+  ss << matrix.format(fmt);
+  return ss.str();
+}
+
+} // kodlab::string

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADER_LIST "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/pi3ha
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_base.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/joint_moteus.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/math.h"
+                "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/string.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/rotations.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/imu_data.h"
                 "${kodlab_mjbots_sdk_SOURCE_DIR}/include/kodlab_mjbots_sdk/log.h"

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 
 #include "kodlab_mjbots_sdk/log.h"
+#include "kodlab_mjbots_sdk/string.h"  // kodlab::string::ScalarVectorToString
 
 namespace kodlab::mjbots {
 void MjbotsHardwareInterface::InitializeCommand() {
@@ -130,11 +131,11 @@ void MjbotsHardwareInterface::SendCommand() {
     commands_[servo].position.feedforward_torque = (dry_run_ ? 0 : joints[servo]->get_servo_torque());
   }
   if (print_torques_) {
-    std::fprintf(stdout, "Torques: ");
-    for (int servo = 0; servo < num_joints_; servo++) {
-      std::fprintf(stdout, "% 8.2f, ", joints[servo]->get_servo_torque());
+    std::vector<float> vec;
+    for (const auto& j : joints) {
+      vec.emplace_back(j->get_servo_torque());
     }
-    std::fprintf(stdout, "\n");
+    LOG_INFO("Torques: %s", kodlab::string::ScalarVectorToString(vec).c_str());
   }
 
   moteus_interface_->Cycle(moteus_data_);


### PR DESCRIPTION
Provides a dry run boolean flag in the `MjbotsControlLoopOptions` struct that runs the control loop and prints the commanded torques but sends zero-torques to the motors.