### PR TITLE
Logging improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ in iterations of the control loop.
 ## Console Logging
 The `log.h` header provides a set of debug logging macros with adjustable
 logging severity levels.  In order of increasing severity, the levels are 
-`DEBUG`, `INFO`, `WARN`, `ERROR`, and `FATAL`.  
+`TRACE`, `DEBUG`, `INFO`, `NOTICE`, `WARN`, `ERROR`, and `FATAL`.  
 
-The minimum level for console output is set by defining `LOG_MIN_SEVERITY` 
-(default is `DEBUG`).  Setting `LOG_MIN_SEVERITY` to `NONE` will disable macro 
-console output.
+The minimum severity level for console output is set by defining the
+`LOG_MIN_SEVERITY` macro (default is `SEVERITY_ALL`).  Setting 
+`LOG_MIN_SEVERITY` to `SEVERITY_NONE` will disable macro console output.
 
 Usage of the `LOG_XXXX` logging macros (where `XXXX` is `DEBUG`, `INFO`,
 etc.) is akin to using [`std::fprintf`](https://en.cppreference.com/w/cpp/io/c/fprintf).
@@ -175,19 +175,23 @@ LOG_IF_INFO(false, "%s", "This info message will not be logged.");
 LOG_IF_FATAL(true, "This fatal message will be logged.");
 ```
 
-The default output of the `LOG_*` macros follows the format 
+Verbose logging commands are provided for all logging macros, and take the form
+`VLOG_XXXX` or `VLOG_IF_XXXX`.  The default output of the log and verbose log 
+macros is as follows. 
 ```
-[SEVERITY][path/to/file | function:line_no] Logged message
+[SEVERITY] Log message
+[SEVERITY][path/to/file | function:line_no] Verbose log message
 ```
-The output behavior can be changed by redefining the `LOG_ARGS` and `LOG_FORMAT` 
-macros.  For example, to produce output of the form 
+The output behavior can be changed by redefining the `LOG_ARGS`, `LOG_FORMAT`,
+`VLOG_ARGS`, and `VLOG_FORMAT` macros.  For example, to produce verbose output 
+of the form 
 ```
-[SEVERITY][path/to/file][line_no][function] Logging message
+[SEVERITY][path/to/file][line_no][function] Verbose log message
 ```
-these macros would be redefined as follows
+the verbose macros would be redefined as follows
 ```cpp
-#define LOG_ARGS(tag) tag, __FILE__, __LINE__, __func__
-#define LOG_FORMAT "[%-5s][%-15s][%d][%s] "
+#define VLOG_ARGS(tag) tag, __FILE__, __LINE__, __func__
+#define VLOG_FORMAT "[%-6s][%-15s][%d][%s] "
 ```
 
 Colored terminal output is provided by default via

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -51,43 +51,87 @@
 // Console Printing                                                          //
 ///////////////////////////////////////////////////////////////////////////////
 
-// String Formatting
-#define NEWLINE "\n"
+// C Escapes
+#define BELL "\a"  ///< Terminal bell character
+#define BACKSPACE "\b"  ///< Backspace character
+#define TAB "\t"  ///< Horizontal tab character
+#define NEWLINE "\n"  ///< Newline character
+#define RETURN "\r"  ///< Carriage return character
 
 // OStreams
-#define STDERR stderr
-#define STDOUT stdout
+#define STDERR stderr  ///< Standard error stream
+#define STDOUT stdout  ///< Standard output stream
 
-// Colors
-#define CONSOLE_SEQ_ESC "\x1b"
-#define CONSOLE_SEQ_BEG "["
-#define CONSOLE_SEQ_SEP ";"
-#define CONSOLE_SEQ_END "m"
-#define FONT_REG "0"
-#define FONT_BOLD "1"
-#define COLOR_RESET "0"
-#define COLOR_BLACK "30"
-#define COLOR_RED "31"
-#define COLOR_GREEN "32"
-#define COLOR_YELLOW "33"
-#define COLOR_BLUE "34"
-#define COLOR_MAGENTA "35"
-#define COLOR_CYAN "36"
-#define COLOR_WHITE "37"
+// ANSI Escape Sequences
+#define CONSOLE_SEQ_ESC "\x1b"  ///< ANSI escape sequence
+#define CONSOLE_SEQ_BEG "["  ///< ANSI begin sequence
+#define CONSOLE_SEQ_SEP ";"  ///< ANSI separation sequence
+#define CONSOLE_SEQ_END "m"  ///< ANSI end sequence
+
+// ANSI Graphics Modes
+#define FONT_REGULAR "0"  ///< ANSI reset mode sequence
+#define FONT_BOLD "1"  ///< ANSI bold mode sequence
+#define FONT_DIM "2"  ///< ANSI dim/faint mode sequence
+#define FONT_ITALIC "3"  ///< ANSI italic mode sequence
+#define FONT_UNDERLINE "4"  ///< ANSI underline mode sequence
+#define FONT_BLINK "5"  ///< ANSI blinking mode sequence
+#define FONT_INVERSE "7"  ///< ANSI inverse/reverse mode sequence
+#define FONT_HIDDEN "8"  ///< ANSI hidden/invisible mode sequence
+#define FONT_STRIKETHROUGH "9"  ///< ANSI strikethrough mode sequence
+
+// ANSI Colors
+#define COLOR_RESET "0"  ///< ANSI reset color and mode sequence
+#define COLOR_BLACK_FG "30"  ///< ANSI black foreground sequence
+#define COLOR_RED_FG "31"  ///< ANSI red foreground sequence
+#define COLOR_GREEN_FG "32"  ///< ANSI green foreground sequence
+#define COLOR_YELLOW_FG "33"  ///< ANSI yellow foreground sequence
+#define COLOR_BLUE_FG "34"  ///< ANSI blue foreground sequence
+#define COLOR_MAGENTA_FG "35"  ///< ANSI magenta foreground sequence
+#define COLOR_CYAN_FG "36"  ///< ANSI cyan foreground sequence
+#define COLOR_WHITE_FG "37"  ///< ANSI white foreground sequence
+#define COLOR_DEFAULT_FG "39"  ///< ANSI default foreground sequence
+#define COLOR_BLACK_BG "40"  ///< ANSI black background sequence
+#define COLOR_RED_BG "41"  ///< ANSI red background sequence
+#define COLOR_GREEN_BG "42"  ///< ANSI green background sequence
+#define COLOR_YELLOW_BG "43"  ///< ANSI yellow background sequence
+#define COLOR_BLUE_BG "44"  ///< ANSI blue background sequence
+#define COLOR_MAGENTA_BG "45"  ///< ANSI magenta background sequence
+#define COLOR_CYAN_BG "46"  ///< ANSI cyan background sequence
+#define COLOR_WHITE_BG "47"  ///< ANSI white background sequence
+#define COLOR_DEFAULT_BG "49"  ///< ANSI default background sequence
+#define COLOR_BRIGHT_BLACK_FG "90"  ///< ANSI BRIGHT black foreground sequence
+#define COLOR_BRIGHT_RED_FG "91"  ///< ANSI BRIGHT red foreground sequence
+#define COLOR_BRIGHT_GREEN_FG "92"  ///< ANSI BRIGHT green foreground sequence
+#define COLOR_BRIGHT_YELLOW_FG "93"  ///< ANSI BRIGHT yellow foreground sequence
+#define COLOR_BRIGHT_BLUE_FG "94"  ///< ANSI BRIGHT blue foreground sequence
+#define COLOR_BRIGHT_MAGENTA_FG "95"  ///< ANSI BRIGHT magenta foreground sequence
+#define COLOR_BRIGHT_CYAN_FG "96"  ///< ANSI BRIGHT cyan foreground sequence
+#define COLOR_BRIGHT_WHITE_FG "97"  ///< ANSI BRIGHT white foreground sequence
+#define COLOR_BRIGHT_BLACK_BG "100"  ///< ANSI BRIGHT black background sequence
+#define COLOR_BRIGHT_RED_BG "101"  ///< ANSI BRIGHT red background sequence
+#define COLOR_BRIGHT_GREEN_BG "102"  ///< ANSI BRIGHT green background sequence
+#define COLOR_BRIGHT_YELLOW_BG "103"  ///< ANSI BRIGHT yellow background sequence
+#define COLOR_BRIGHT_BLUE_BG "104"  ///< ANSI BRIGHT blue background sequence
+#define COLOR_BRIGHT_MAGENTA_BG "105"  ///< ANSI BRIGHT magenta background sequence
+#define COLOR_BRIGHT_CYAN_BG "106"  ///< ANSI BRIGHT cyan background sequence
+#define COLOR_BRIGHT_WHITE_BG "107"  ///< ANSI BRIGHT white background sequence
 
 // Color Convenience
 #define FMT_TEXT(font, color) \
   CONSOLE_SEQ_ESC CONSOLE_SEQ_BEG font CONSOLE_SEQ_SEP color CONSOLE_SEQ_END
-#define RESET_COLOR FMT_TEXT(FONT_REG, COLOR_RESET)
+#define FMT_TEXT_BG(font, fg_color, bg_color) \
+  CONSOLE_SEQ_ESC CONSOLE_SEQ_BEG font CONSOLE_SEQ_SEP bg_color CONSOLE_SEQ_SEP fg_color CONSOLE_SEQ_END
+#define RESET_COLOR FMT_TEXT(FONT_REGULAR, COLOR_RESET)
 
 // Console printing via ostreams
-#define PRINT(ostream, ...) std::fprintf(ostream, __VA_ARGS__)
+#define PRINT(ostream, str, args...) std::fprintf(ostream, str NEWLINE, ##args)
 
 // Color printing
 #ifndef NO_COLOR
-#define PRINT_COLOR(ostream, color, str, ...) std::fprintf(ostream, str, __VA_ARGS__)
+#define PRINT_FMT(ostream, ansi_fmt, str, args...) \
+  std::fprintf(ostream, ansi_fmt str RESET_COLOR NEWLINE, ##args)
 #else
-#define PRINT_COLOR(ostream, color, str, ...) PRINT(ostream, __VA_ARGS__)
+#define PRINT_FMT(ostream, color, str, args...) PRINT(ostream, ##args)
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -115,13 +159,13 @@
 #define TAG_FATAL "FATAL"
 
 // Log Severity Tags
-#define COLOR_TRACE FMT_TEXT(FONT_REG, COLOR_MAGENTA)
-#define COLOR_DEBUG FMT_TEXT(FONT_REG, COLOR_BLUE)
-#define COLOR_INFO FMT_TEXT(FONT_REG, COLOR_WHITE)
-#define COLOR_NOTICE FMT_TEXT(FONT_REG, COLOR_GREEN)
-#define COLOR_WARN FMT_TEXT(FONT_REG, COLOR_YELLOW)
-#define COLOR_ERROR FMT_TEXT(FONT_REG, COLOR_RED)
-#define COLOR_FATAL FMT_TEXT(FONT_BOLD, COLOR_RED)
+#define COLOR_TRACE FMT_TEXT(FONT_REGULAR, COLOR_MAGENTA_FG)
+#define COLOR_DEBUG FMT_TEXT(FONT_REGULAR, COLOR_BLUE_FG)
+#define COLOR_INFO FMT_TEXT(FONT_REGULAR, COLOR_WHITE_FG)
+#define COLOR_NOTICE FMT_TEXT(FONT_REGULAR, COLOR_GREEN_FG)
+#define COLOR_WARN FMT_TEXT(FONT_REGULAR, COLOR_YELLOW_FG)
+#define COLOR_ERROR FMT_TEXT(FONT_REGULAR, COLOR_RED_FG)
+#define COLOR_FATAL FMT_TEXT(FONT_BOLD, COLOR_RED_FG)
 
 // Log arguments & formatting flags
 // TODO(ethanmusser): Add time to log output.
@@ -147,19 +191,19 @@
 
 // Log to console
 // TODO(ethanmusser): Implement logging to file.
-#define LOG(msg, tag, args...) PRINT(LOG_OSTREAM, LOG_FORMAT msg NEWLINE, LOG_ARGS(tag), ##args)
-#define VLOG(msg, tag, args...) PRINT(LOG_OSTREAM, VLOG_FORMAT msg NEWLINE, VLOG_ARGS(tag), ##args)
+#define LOG(msg, tag, args...) PRINT(LOG_OSTREAM, LOG_FORMAT msg, LOG_ARGS(tag), ##args)
+#define VLOG(msg, tag, args...) PRINT(LOG_OSTREAM, VLOG_FORMAT msg, VLOG_ARGS(tag), ##args)
 #ifndef NO_COLOR
-#define LOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color LOG_FORMAT msg NEWLINE RESET_COLOR, LOG_ARGS(tag), ##args)
-#define VLOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color VLOG_FORMAT msg NEWLINE RESET_COLOR, VLOG_ARGS(tag), ##args)
+#define LOG_COLOR(msg, tag, color, args...) PRINT_FMT(LOG_OSTREAM, color, LOG_FORMAT msg RESET_COLOR, LOG_ARGS(tag), ##args)
+#define VLOG_COLOR(msg, tag, color, args...) PRINT_FMT(LOG_OSTREAM, color, VLOG_FORMAT msg RESET_COLOR, VLOG_ARGS(tag), ##args)
 #else
 #define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
 #define VLOG_COLOR(msg, tag, color, args...) VLOG(msg, tag, args)
 #endif
 
-// Minimum log severity (default TRACE)
+// Minimum log severity (default ALL)
 #ifndef LOG_MIN_SEVERITY
-#define LOG_MIN_SEVERITY SEVERITY_TRACE
+#define LOG_MIN_SEVERITY SEVERITY_ALL
 #endif
 
 // Trace logging

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -154,81 +154,77 @@
 // Trace logging
 #if LOG_MIN_SEVERITY <= SEVERITY_TRACE
 #define LOG_TRACE(message, args...) LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
+#define LOG_IF_TRACE(condition, message, args...) \
+    if (condition)                                \
+    LOG_TRACE(message, ##args)
 #else
 #define LOG_TRACE(message, args...)
+#define LOG_IF_TRACE(condition, message, args...)
 #endif
 
 // Debug logging
 #if LOG_MIN_SEVERITY <= SEVERITY_DEBUG
 #define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+#define LOG_IF_DEBUG(condition, message, args...) \
+    if (condition)                                \
+    LOG_DEBUG(message, ##args)
 #else
 #define LOG_DEBUG(message, args...)
+#define LOG_IF_DEBUG(condition, message, args...)
 #endif
 
 // Info logging
 #if LOG_MIN_SEVERITY <= SEVERITY_INFO
 #define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+#define LOG_IF_INFO(condition, message, args...) \
+    if (condition)                               \
+    LOG_INFO(message, ##args)
 #else
 #define LOG_INFO(message, args...)
+#define LOG_IF_INFO(condition, message, args...)
 #endif
 
 // Notice logging
 #if LOG_MIN_SEVERITY <= SEVERITY_NOTICE
 #define LOG_NOTICE(message, args...) LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
+#define LOG_IF_NOTICE(condition, message, args...) \
+    if (condition)                                \
+    LOG_NOTICE(message, ##args)
 #else
 #define LOG_NOTICE(message, args...)
+#define LOG_IF_NOTICE(condition, message, args...)
 #endif
 
 // Warn logging
 #if LOG_MIN_SEVERITY <= SEVERITY_WARN
 #define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+#define LOG_IF_WARN(condition, message, args...) \
+    if (condition)                               \
+    LOG_WARN(message, ##args)
 #else
 #define LOG_WARN(message, args...)
+#define LOG_IF_WARN(condition, message, args...)
 #endif
 
 // Error logging
 #if LOG_MIN_SEVERITY <= SEVERITY_ERROR
 #define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+#define LOG_IF_ERROR(condition, message, args...) \
+    if (condition)                                \
+    LOG_ERROR(message, ##args)
 #else
 #define LOG_ERROR(message, args...)
+#define LOG_IF_ERROR(condition, message, args...)
 #endif
 
 // Fatal logging
 #if LOG_MIN_SEVERITY <= SEVERITY_FATAL
 #define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
-#else
-#define LOG_FATAL(message, args...)
-#endif
-
-// Conditional logs (always defined)
-#if LOG_MIN_SEVERITY <= SEVERITY_NONE
-#define LOG_IF_TRACE(condition, message, args...) \
-    if (condition)                                \
-    LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
-#define LOG_IF_DEBUG(condition, message, args...) \
-    if (condition)                                \
-    LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
-#define LOG_IF_INFO(condition, message, args...) \
-    if (condition)                               \
-    LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
-#define LOG_IF_NOTICE(condition, message, args...) \
-    if (condition)                                \
-    LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
-#define LOG_IF_WARN(condition, message, args...) \
-    if (condition)                               \
-    LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
-#define LOG_IF_ERROR(condition, message, args...) \
-    if (condition)                                \
-    LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
 #define LOG_IF_FATAL(condition, message, args...) \
     if (condition)                                \
-    LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+    LOG_FATAL(message, ##args)
 #else
-#define LOG_IF_TRACE(condition, message, args...)
-#define LOG_IF_DEBUG(condition, message, args...)
-#define LOG_IF_INFO(condition, message, args...)
-#define LOG_IF_NOTICE(condition, message, args...)
-#define LOG_IF_WARN(condition, message, args...)
-#define LOG_IF_ERROR(condition, message, args...)
+#define LOG_FATAL(message, args...)
 #define LOG_IF_FATAL(condition, message, args...)
 #endif
+

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -95,32 +95,42 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 // Log Severity Levels
-#define SEVERITY_DEBUG 0
-#define SEVERITY_INFO 1
-#define SEVERITY_WARN 2
-#define SEVERITY_ERROR 3
-#define SEVERITY_FATAL 4
-#define SEVERITY_NONE 5
+#define SEVERITY_ALL 0
+#define SEVERITY_TRACE 1
+#define SEVERITY_DEBUG 2
+#define SEVERITY_INFO 3
+#define SEVERITY_NOTICE 4
+#define SEVERITY_WARN 5
+#define SEVERITY_ERROR 6
+#define SEVERITY_FATAL 7
+#define SEVERITY_NONE 8
 
 // Log Severity Tags
+#define TAG_TRACE "TRACE"
 #define TAG_DEBUG "DEBUG"
 #define TAG_INFO "INFO"
+#define TAG_NOTICE "NOTICE"
 #define TAG_WARN "WARN"
 #define TAG_ERROR "ERROR"
 #define TAG_FATAL "FATAL"
-#define TAG_NONE "NONE"
 
 // Log Severity Tags
+#define COLOR_TRACE FMT_TEXT(FONT_REG, COLOR_MAGENTA)
 #define COLOR_DEBUG FMT_TEXT(FONT_REG, COLOR_BLUE)
 #define COLOR_INFO FMT_TEXT(FONT_REG, COLOR_WHITE)
+#define COLOR_NOTICE FMT_TEXT(FONT_REG, COLOR_GREEN)
 #define COLOR_WARN FMT_TEXT(FONT_REG, COLOR_YELLOW)
 #define COLOR_ERROR FMT_TEXT(FONT_REG, COLOR_RED)
 #define COLOR_FATAL FMT_TEXT(FONT_BOLD, COLOR_RED)
 
 // Log arguments & formatting flags
 // TODO(ethanmusser): Add time to log output.
+#ifndef LOG_ARGS
 #define LOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
-#define LOG_FORMAT "[%-5s][%-15s | %s:%d] "
+#endif
+#ifndef LOG_FORMAT
+#define LOG_FORMAT "[%-6s][%-15s | %s:%d] "
+#endif
 
 // Default ostream (default STDERR)
 #ifndef LOG_OSTREAM
@@ -138,52 +148,72 @@
 
 // Minimum log severity (default DEBUG)
 #ifndef LOG_MIN_SEVERITY
-#define LOG_MIN_SEVERITY SEVERITY_DEBUG
+#define LOG_MIN_SEVERITY SEVERITY_TRACE
+#endif
+
+// Trace logging
+#if LOG_MIN_SEVERITY <= SEVERITY_TRACE
+#define LOG_TRACE(message, args...) LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
+#else
+#define LOG_TRACE(message, args...)
 #endif
 
 // Debug logging
-#if LOG_MIN_SEVERITY <= DEBUG_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_DEBUG
 #define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
 #else
 #define LOG_DEBUG(message, args...)
 #endif
 
 // Info logging
-#if LOG_MIN_SEVERITY <= INFO_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_INFO
 #define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
 #else
 #define LOG_INFO(message, args...)
 #endif
 
+// Notice logging
+#if LOG_MIN_SEVERITY <= SEVERITY_NOTICE
+#define LOG_NOTICE(message, args...) LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
+#else
+#define LOG_NOTICE(message, args...)
+#endif
+
 // Warn logging
-#if LOG_MIN_SEVERITY <= WARN_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_WARN
 #define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
 #else
 #define LOG_WARN(message, args...)
 #endif
 
 // Error logging
-#if LOG_MIN_SEVERITY <= ERROR_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_ERROR
 #define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
 #else
 #define LOG_ERROR(message, args...)
 #endif
 
 // Fatal logging
-#if LOG_MIN_SEVERITY <= FATAL_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_FATAL
 #define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
 #else
 #define LOG_FATAL(message, args...)
 #endif
 
 // Conditional logs (always defined)
-#if LOG_MIN_SEVERITY <= NONE_LEVEL
+#if LOG_MIN_SEVERITY <= SEVERITY_NONE
+#define LOG_IF_TRACE(condition, message, args...) \
+    if (condition)                                \
+    LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
 #define LOG_IF_DEBUG(condition, message, args...) \
     if (condition)                                \
     LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
 #define LOG_IF_INFO(condition, message, args...) \
     if (condition)                               \
     LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+#define LOG_IF_NOTICE(condition, message, args...) \
+    if (condition)                                \
+    LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
 #define LOG_IF_WARN(condition, message, args...) \
     if (condition)                               \
     LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
@@ -194,8 +224,10 @@
     if (condition)                                \
     LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
 #else
+#define LOG_IF_TRACE(condition, message, args...)
+#define LOG_IF_DEBUG(condition, message, args...)
 #define LOG_IF_INFO(condition, message, args...)
-#define LOG_IF_INFO(condition, message, args...)
+#define LOG_IF_NOTICE(condition, message, args...)
 #define LOG_IF_WARN(condition, message, args...)
 #define LOG_IF_ERROR(condition, message, args...)
 #define LOG_IF_FATAL(condition, message, args...)

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -126,10 +126,18 @@
 // Log arguments & formatting flags
 // TODO(ethanmusser): Add time to log output.
 #ifndef LOG_ARGS
-#define LOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
+#define LOG_ARGS(tag) tag
 #endif
 #ifndef LOG_FORMAT
-#define LOG_FORMAT "[%-6s][%-15s | %s:%d] "
+#define LOG_FORMAT "[%-6s] "
+#endif
+
+// Verbose log arguments & formatting flags
+#ifndef VLOG_ARGS
+#define VLOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
+#endif
+#ifndef VLOG_FORMAT
+#define VLOG_FORMAT "[%-6s][%-15s | %s:%d] "
 #endif
 
 // Default ostream (default STDERR)
@@ -140,13 +148,16 @@
 // Log to console
 // TODO(ethanmusser): Implement logging to file.
 #define LOG(msg, tag, args...) PRINT(LOG_OSTREAM, LOG_FORMAT msg NEWLINE, LOG_ARGS(tag), ##args)
+#define VLOG(msg, tag, args...) PRINT(LOG_OSTREAM, VLOG_FORMAT msg NEWLINE, VLOG_ARGS(tag), ##args)
 #ifndef NO_COLOR
 #define LOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color LOG_FORMAT msg NEWLINE RESET_COLOR, LOG_ARGS(tag), ##args)
+#define VLOG_COLOR(msg, tag, color, args...) PRINT(LOG_OSTREAM, color VLOG_FORMAT msg NEWLINE RESET_COLOR, VLOG_ARGS(tag), ##args)
 #else
 #define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
+#define VLOG_COLOR(msg, tag, color, args...) VLOG(msg, tag, args)
 #endif
 
-// Minimum log severity (default DEBUG)
+// Minimum log severity (default TRACE)
 #ifndef LOG_MIN_SEVERITY
 #define LOG_MIN_SEVERITY SEVERITY_TRACE
 #endif
@@ -154,77 +165,119 @@
 // Trace logging
 #if LOG_MIN_SEVERITY <= SEVERITY_TRACE
 #define LOG_TRACE(message, args...) LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
+#define VLOG_TRACE(message, args...) VLOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
 #define LOG_IF_TRACE(condition, message, args...) \
     if (condition)                                \
     LOG_TRACE(message, ##args)
+#define VLOG_IF_TRACE(condition, message, args...) \
+    if (condition)                                \
+    VLOG_TRACE(message, ##args)
 #else
 #define LOG_TRACE(message, args...)
+#define VLOG_TRACE(message, args...)
 #define LOG_IF_TRACE(condition, message, args...)
+#define VLOG_IF_TRACE(condition, message, args...)
 #endif
 
 // Debug logging
 #if LOG_MIN_SEVERITY <= SEVERITY_DEBUG
 #define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+#define VLOG_DEBUG(message, args...) VLOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
 #define LOG_IF_DEBUG(condition, message, args...) \
     if (condition)                                \
     LOG_DEBUG(message, ##args)
+#define VLOG_IF_DEBUG(condition, message, args...) \
+    if (condition)                                \
+    VLOG_DEBUG(message, ##args)
 #else
 #define LOG_DEBUG(message, args...)
+#define VLOG_DEBUG(message, args...)
 #define LOG_IF_DEBUG(condition, message, args...)
+#define VLOG_IF_DEBUG(condition, message, args...)
 #endif
 
 // Info logging
 #if LOG_MIN_SEVERITY <= SEVERITY_INFO
 #define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+#define VLOG_INFO(message, args...) VLOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
 #define LOG_IF_INFO(condition, message, args...) \
     if (condition)                               \
     LOG_INFO(message, ##args)
+#define VLOG_IF_INFO(condition, message, args...) \
+    if (condition)                               \
+    VLOG_INFO(message, ##args)
 #else
 #define LOG_INFO(message, args...)
+#define VLOG_INFO(message, args...)
 #define LOG_IF_INFO(condition, message, args...)
+#define VLOG_IF_INFO(condition, message, args...)
 #endif
 
 // Notice logging
 #if LOG_MIN_SEVERITY <= SEVERITY_NOTICE
 #define LOG_NOTICE(message, args...) LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
+#define VLOG_NOTICE(message, args...) VLOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
 #define LOG_IF_NOTICE(condition, message, args...) \
     if (condition)                                \
     LOG_NOTICE(message, ##args)
+#define VLOG_IF_NOTICE(condition, message, args...) \
+    if (condition)                                \
+    VLOG_NOTICE(message, ##args)
 #else
 #define LOG_NOTICE(message, args...)
+#define VLOG_NOTICE(message, args...)
 #define LOG_IF_NOTICE(condition, message, args...)
+#define VLOG_IF_NOTICE(condition, message, args...)
 #endif
 
 // Warn logging
 #if LOG_MIN_SEVERITY <= SEVERITY_WARN
 #define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+#define VLOG_WARN(message, args...) VLOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
 #define LOG_IF_WARN(condition, message, args...) \
     if (condition)                               \
     LOG_WARN(message, ##args)
+#define VLOG_IF_WARN(condition, message, args...) \
+    if (condition)                               \
+    VLOG_WARN(message, ##args)
 #else
 #define LOG_WARN(message, args...)
+#define VLOG_WARN(message, args...)
 #define LOG_IF_WARN(condition, message, args...)
+#define VLOG_IF_WARN(condition, message, args...)
 #endif
 
 // Error logging
 #if LOG_MIN_SEVERITY <= SEVERITY_ERROR
 #define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+#define VLOG_ERROR(message, args...) VLOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
 #define LOG_IF_ERROR(condition, message, args...) \
     if (condition)                                \
     LOG_ERROR(message, ##args)
+#define VLOG_IF_ERROR(condition, message, args...) \
+    if (condition)                                \
+    VLOG_ERROR(message, ##args)
 #else
 #define LOG_ERROR(message, args...)
+#define VLOG_ERROR(message, args...)
 #define LOG_IF_ERROR(condition, message, args...)
+#define VLOG_IF_ERROR(condition, message, args...)
 #endif
 
 // Fatal logging
 #if LOG_MIN_SEVERITY <= SEVERITY_FATAL
 #define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+#define VLOG_FATAL(message, args...) VLOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
 #define LOG_IF_FATAL(condition, message, args...) \
     if (condition)                                \
     LOG_FATAL(message, ##args)
+#define VLOG_IF_FATAL(condition, message, args...) \
+    if (condition)                                \
+    VLOG_FATAL(message, ##args)
 #else
 #define LOG_FATAL(message, args...)
+#define VLOG_FATAL(message, args...)
 #define LOG_IF_FATAL(condition, message, args...)
+#define VLOG_IF_FATAL(condition, message, args...)
 #endif
 

--- a/include/kodlab_mjbots_sdk/log.h
+++ b/include/kodlab_mjbots_sdk/log.h
@@ -165,19 +165,19 @@
 #define PRINT(ostream, str, args...) std::fprintf(ostream, str NEWLINE, ##args)
 
 #ifndef NO_COLOR
-/**
- * @brief Print to console in color via an output stream
- * @param ostream output stream
- * @param ansi_fmt ANSI format sequence beginning with `CONSOLE_SEQ_ESC` and
- * `CONSOLE_SEQ_BEG`, and ending with `CONSOLE_SEQ_END`.  Use `FMT_TEXT` or
- * `FMT_TEXT_BG` macros to formulate this argument.
- * @param str string to be formatted and printed
- * @param args string format arguments
- */
-#define PRINT_FMT(ostream, ansi_fmt, str, args...) \
-  std::fprintf(ostream, ansi_fmt str RESET_COLOR NEWLINE, ##args)
+  /**
+   * @brief Print to console in color via an output stream
+   * @param ostream output stream
+   * @param ansi_fmt ANSI format sequence beginning with `CONSOLE_SEQ_ESC` and
+   * `CONSOLE_SEQ_BEG`, and ending with `CONSOLE_SEQ_END`.  Use `FMT_TEXT` or
+   * `FMT_TEXT_BG` macros to formulate this argument.
+   * @param str string to be formatted and printed
+   * @param args string format arguments
+   */
+  #define PRINT_FMT(ostream, ansi_fmt, str, args...) \
+    std::fprintf(ostream, ansi_fmt str RESET_COLOR NEWLINE, ##args)
 #else
-#define PRINT_FMT(ostream, color, str, args...) PRINT(ostream, ##args)
+  #define PRINT_FMT(ostream, color, str, args...) PRINT(ostream, ##args)
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -214,29 +214,29 @@
 #define COLOR_FATAL FMT_TEXT(FONT_BOLD, COLOR_RED_FG)  ///< Fatal ANSI font/color sequence
 
 #ifndef LOG_ARGS
-/**
- * @brief Log arguments
- * @param tag log severity tag
- */
-#define LOG_ARGS(tag) tag
+  /**
+   * @brief Log arguments
+   * @param tag log severity tag
+   */
+  #define LOG_ARGS(tag) tag
 #endif
 #ifndef LOG_FORMAT
-#define LOG_FORMAT "[%-6s] " ///< Log format string
+  #define LOG_FORMAT "[%-6s] " ///< Log format string
 #endif
 
 #ifndef VLOG_ARGS
-/**
- * @brief Verbose log arguments
- * @param tag log severity tag
- */
-#define VLOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
+  /**
+   * @brief Verbose log arguments
+   * @param tag log severity tag
+   */
+  #define VLOG_ARGS(tag) tag, __FILE__, __func__, __LINE__
 #endif
 #ifndef VLOG_FORMAT
-#define VLOG_FORMAT "[%-6s][%-15s | %s:%d] "  ///< Verbose log format string
+  #define VLOG_FORMAT "[%-6s][%-15s | %s:%d] "  ///< Verbose log format string
 #endif
 
 #ifndef LOG_OSTREAM
-#define LOG_OSTREAM STDERR  ///< Logging output stream (default STDERR)
+  #define LOG_OSTREAM STDERR  ///< Logging output stream (default STDERR)
 #endif
 
 /**
@@ -256,323 +256,323 @@
 #define VLOG(msg, tag, args...) PRINT(LOG_OSTREAM, VLOG_FORMAT msg, VLOG_ARGS(tag), ##args)
 
 #ifndef NO_COLOR
-/**
- * @brief Log formatted message with severity tag to console
- * @param msg string to be formatted and logged
- * @param tag log severity tag
- * @param fmt_seq ANSI format sequence
- * @param args string format arguments
- */
-#define LOG_COLOR(msg, tag, fmt_seq, args...) PRINT_FMT(LOG_OSTREAM, fmt_seq, LOG_FORMAT msg RESET_COLOR, LOG_ARGS(tag), ##args)
+  /**
+   * @brief Log formatted message with severity tag to console
+   * @param msg string to be formatted and logged
+   * @param tag log severity tag
+   * @param fmt_seq ANSI format sequence
+   * @param args string format arguments
+   */
+  #define LOG_COLOR(msg, tag, fmt_seq, args...) PRINT_FMT(LOG_OSTREAM, fmt_seq, LOG_FORMAT msg RESET_COLOR, LOG_ARGS(tag), ##args)
 
-/**
- * @brief Verbosely log formatted message with severity tag to console
- * @param msg string to be formatted and logged
- * @param tag log severity tag
- * @param fmt_seq ANSI format sequence
- * @param args string format arguments
- */
-#define VLOG_COLOR(msg, tag, fmt_seq, args...) PRINT_FMT(LOG_OSTREAM, fmt_seq, VLOG_FORMAT msg RESET_COLOR, VLOG_ARGS(tag), ##args)
+  /**
+   * @brief Verbosely log formatted message with severity tag to console
+   * @param msg string to be formatted and logged
+   * @param tag log severity tag
+   * @param fmt_seq ANSI format sequence
+   * @param args string format arguments
+   */
+  #define VLOG_COLOR(msg, tag, fmt_seq, args...) PRINT_FMT(LOG_OSTREAM, fmt_seq, VLOG_FORMAT msg RESET_COLOR, VLOG_ARGS(tag), ##args)
 #else
-#define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
-#define VLOG_COLOR(msg, tag, color, args...) VLOG(msg, tag, args)
+  #define LOG_COLOR(msg, tag, color, args...) LOG(msg, tag, args)
+  #define VLOG_COLOR(msg, tag, color, args...) VLOG(msg, tag, args)
 #endif
 
 #ifndef LOG_MIN_SEVERITY
-#define LOG_MIN_SEVERITY SEVERITY_ALL  ///< Minimum log severity (default SEVERITY_ALL)
+  #define LOG_MIN_SEVERITY SEVERITY_ALL  ///< Minimum log severity (default SEVERITY_ALL)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_TRACE
-/**
- * @brief Log message to console with `TRACE` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_TRACE(message, args...) LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
+  /**
+   * @brief Log message to console with `TRACE` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_TRACE(message, args...) LOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
 
-/**
- * @brief Log verbose message to console with `TRACE` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_TRACE(message, args...) VLOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
+  /**
+   * @brief Log verbose message to console with `TRACE` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_TRACE(message, args...) VLOG_COLOR(message, TAG_TRACE, COLOR_TRACE, ##args)
 
-/**
- * @brief Conditionally log message to console with `TRACE` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_TRACE(condition, message, args...) \
-    if (condition)                                \
-    LOG_TRACE(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `TRACE` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_TRACE(condition, message, args...) \
+      if (condition)                                \
+      LOG_TRACE(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `TRACE` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_TRACE(condition, message, args...) \
-    if (condition)                                \
-    VLOG_TRACE(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `TRACE` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_TRACE(condition, message, args...) \
+      if (condition)                                \
+      VLOG_TRACE(message, ##args)
 #else
-#define LOG_TRACE(message, args...)
-#define VLOG_TRACE(message, args...)
-#define LOG_IF_TRACE(condition, message, args...)
-#define VLOG_IF_TRACE(condition, message, args...)
+  #define LOG_TRACE(message, args...)
+  #define VLOG_TRACE(message, args...)
+  #define LOG_IF_TRACE(condition, message, args...)
+  #define VLOG_IF_TRACE(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_DEBUG
-/**
- * @brief Log message to console with `DEBUG` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+  /**
+   * @brief Log message to console with `DEBUG` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_DEBUG(message, args...) LOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
 
-/**
- * @brief Log verbose message to console with `DEBUG` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_DEBUG(message, args...) VLOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
+  /**
+   * @brief Log verbose message to console with `DEBUG` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_DEBUG(message, args...) VLOG_COLOR(message, TAG_DEBUG, COLOR_DEBUG, ##args)
 
-/**
- * @brief Conditionally log message to console with `DEBUG` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_DEBUG(condition, message, args...) \
-    if (condition)                                \
-    LOG_DEBUG(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `DEBUG` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_DEBUG(condition, message, args...) \
+      if (condition)                                \
+      LOG_DEBUG(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `DEBUG` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_DEBUG(condition, message, args...) \
-    if (condition)                                \
-    VLOG_DEBUG(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `DEBUG` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_DEBUG(condition, message, args...) \
+      if (condition)                                \
+      VLOG_DEBUG(message, ##args)
 #else
-#define LOG_DEBUG(message, args...)
-#define VLOG_DEBUG(message, args...)
-#define LOG_IF_DEBUG(condition, message, args...)
-#define VLOG_IF_DEBUG(condition, message, args...)
+  #define LOG_DEBUG(message, args...)
+  #define VLOG_DEBUG(message, args...)
+  #define LOG_IF_DEBUG(condition, message, args...)
+  #define VLOG_IF_DEBUG(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_INFO
-/**
- * @brief Log message to console with `INFO` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+  /**
+   * @brief Log message to console with `INFO` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_INFO(message, args...) LOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
 
-/**
- * @brief Log verbose message to console with `INFO` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_INFO(message, args...) VLOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
+  /**
+   * @brief Log verbose message to console with `INFO` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_INFO(message, args...) VLOG_COLOR(message, TAG_INFO, COLOR_INFO, ##args)
 
-/**
- * @brief Conditionally log message to console with `INFO` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_INFO(condition, message, args...) \
-    if (condition)                               \
-    LOG_INFO(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `INFO` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_INFO(condition, message, args...) \
+      if (condition)                               \
+      LOG_INFO(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `INFO` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_INFO(condition, message, args...) \
-    if (condition)                               \
-    VLOG_INFO(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `INFO` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_INFO(condition, message, args...) \
+      if (condition)                               \
+      VLOG_INFO(message, ##args)
 #else
-#define LOG_INFO(message, args...)
-#define VLOG_INFO(message, args...)
-#define LOG_IF_INFO(condition, message, args...)
-#define VLOG_IF_INFO(condition, message, args...)
+  #define LOG_INFO(message, args...)
+  #define VLOG_INFO(message, args...)
+  #define LOG_IF_INFO(condition, message, args...)
+  #define VLOG_IF_INFO(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_NOTICE
-/**
- * @brief Log message to console with `NOTICE` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_NOTICE(message, args...) LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
+  /**
+   * @brief Log message to console with `NOTICE` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_NOTICE(message, args...) LOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
 
-/**
- * @brief Log verbose message to console with `NOTICE` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_NOTICE(message, args...) VLOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
+  /**
+   * @brief Log verbose message to console with `NOTICE` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_NOTICE(message, args...) VLOG_COLOR(message, TAG_NOTICE, COLOR_NOTICE, ##args)
 
-/**
- * @brief Conditionally log message to console with `NOTICE` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_NOTICE(condition, message, args...) \
-    if (condition)                                \
-    LOG_NOTICE(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `NOTICE` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_NOTICE(condition, message, args...) \
+      if (condition)                                \
+      LOG_NOTICE(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `NOTICE` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_NOTICE(condition, message, args...) \
-    if (condition)                                \
-    VLOG_NOTICE(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `NOTICE` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_NOTICE(condition, message, args...) \
+      if (condition)                                \
+      VLOG_NOTICE(message, ##args)
 #else
-#define LOG_NOTICE(message, args...)
-#define VLOG_NOTICE(message, args...)
-#define LOG_IF_NOTICE(condition, message, args...)
-#define VLOG_IF_NOTICE(condition, message, args...)
+  #define LOG_NOTICE(message, args...)
+  #define VLOG_NOTICE(message, args...)
+  #define LOG_IF_NOTICE(condition, message, args...)
+  #define VLOG_IF_NOTICE(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_WARN
-/**
- * @brief Log message to console with `WARN` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+  /**
+   * @brief Log message to console with `WARN` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_WARN(message, args...) LOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
 
-/**
- * @brief Log verbose message to console with `WARN` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_WARN(message, args...) VLOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
+  /**
+   * @brief Log verbose message to console with `WARN` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_WARN(message, args...) VLOG_COLOR(message, TAG_WARN, COLOR_WARN, ##args)
 
-/**
- * @brief Conditionally log message to console with `WARN` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_WARN(condition, message, args...) \
-    if (condition)                               \
-    LOG_WARN(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `WARN` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_WARN(condition, message, args...) \
+      if (condition)                               \
+      LOG_WARN(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `WARN` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_WARN(condition, message, args...) \
-    if (condition)                               \
-    VLOG_WARN(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `WARN` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_WARN(condition, message, args...) \
+      if (condition)                               \
+      VLOG_WARN(message, ##args)
 #else
-#define LOG_WARN(message, args...)
-#define VLOG_WARN(message, args...)
-#define LOG_IF_WARN(condition, message, args...)
-#define VLOG_IF_WARN(condition, message, args...)
+  #define LOG_WARN(message, args...)
+  #define VLOG_WARN(message, args...)
+  #define LOG_IF_WARN(condition, message, args...)
+  #define VLOG_IF_WARN(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_ERROR
-/**
- * @brief Log message to console with `ERROR` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+  /**
+   * @brief Log message to console with `ERROR` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_ERROR(message, args...) LOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
 
-/**
- * @brief Log verbose message to console with `ERROR` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_ERROR(message, args...) VLOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
+  /**
+   * @brief Log verbose message to console with `ERROR` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_ERROR(message, args...) VLOG_COLOR(message, TAG_ERROR, COLOR_ERROR, ##args)
 
-/**
- * @brief Conditionally log message to console with `ERROR` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_ERROR(condition, message, args...) \
-    if (condition)                                \
-    LOG_ERROR(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `ERROR` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_ERROR(condition, message, args...) \
+      if (condition)                                \
+      LOG_ERROR(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `ERROR` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_ERROR(condition, message, args...) \
-    if (condition)                                \
-    VLOG_ERROR(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `ERROR` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_ERROR(condition, message, args...) \
+      if (condition)                                \
+      VLOG_ERROR(message, ##args)
 #else
-#define LOG_ERROR(message, args...)
-#define VLOG_ERROR(message, args...)
-#define LOG_IF_ERROR(condition, message, args...)
-#define VLOG_IF_ERROR(condition, message, args...)
+  #define LOG_ERROR(message, args...)
+  #define VLOG_ERROR(message, args...)
+  #define LOG_IF_ERROR(condition, message, args...)
+  #define VLOG_IF_ERROR(condition, message, args...)
 #endif
 
 #if LOG_MIN_SEVERITY <= SEVERITY_FATAL
-/**
- * @brief Log message to console with `FATAL` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+  /**
+   * @brief Log message to console with `FATAL` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_FATAL(message, args...) LOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
 
-/**
- * @brief Log verbose message to console with `FATAL` severity level
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_FATAL(message, args...) VLOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
+  /**
+   * @brief Log verbose message to console with `FATAL` severity level
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_FATAL(message, args...) VLOG_COLOR(message, TAG_FATAL, COLOR_FATAL, ##args)
 
-/**
- * @brief Conditionally log message to console with `FATAL` severity level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define LOG_IF_FATAL(condition, message, args...) \
-    if (condition)                                \
-    LOG_FATAL(message, ##args)
+  /**
+   * @brief Conditionally log message to console with `FATAL` severity level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define LOG_IF_FATAL(condition, message, args...) \
+      if (condition)                                \
+      LOG_FATAL(message, ##args)
 
-/**
- * @brief Conditionally log verbose message to console with `FATAL` severity
- * level
- * @param condition condition dictating whether to log
- * @param message string to be formatted and logged
- * @param args string format arguments
- */
-#define VLOG_IF_FATAL(condition, message, args...) \
-    if (condition)                                \
-    VLOG_FATAL(message, ##args)
+  /**
+   * @brief Conditionally log verbose message to console with `FATAL` severity
+   * level
+   * @param condition condition dictating whether to log
+   * @param message string to be formatted and logged
+   * @param args string format arguments
+   */
+  #define VLOG_IF_FATAL(condition, message, args...) \
+      if (condition)                                \
+      VLOG_FATAL(message, ##args)
 #else
-#define LOG_FATAL(message, args...)
-#define VLOG_FATAL(message, args...)
-#define LOG_IF_FATAL(condition, message, args...)
-#define VLOG_IF_FATAL(condition, message, args...)
+  #define LOG_FATAL(message, args...)
+  #define VLOG_FATAL(message, args...)
+  #define LOG_IF_FATAL(condition, message, args...)
+  #define VLOG_IF_FATAL(condition, message, args...)
 #endif
 


### PR DESCRIPTION
Fixes some bugs in the logging macro formatting, adds some additional logging levels, and provides a verbose logging option to prevent bogging down the system with excessive printing.

### Changelist

- Fixes bugs with the formatting of log messages with newlines
- Fixes incomplete `PRINT_FMT` printing macro for general purpose formatted printing
- Provides additional log severity levels: `TRACE` and `NOTICE`
- Modifies `LOG_*` macros to be non-verbose and adds separate, verbose log macros `VLOG_*`
- Adds additional ANSI graphics and color modes
- Fixes documentation in `log.h` to work with Doxygen

### Testing

Tested in the example files. The default output looks like the following, where the top two blocks are non-verbose, and the bottom two blocks are verbose.

![image](https://user-images.githubusercontent.com/15707116/185811594-34e8715f-3fdb-4248-8bfc-fc5a286fb3f2.png)

### Future Considerations

It might be worth moving to a proper logging library.  [spdlog](https://github.com/gabime/spdlog) looks promising.  [glog](https://github.com/google/glog) is another popular solution.


