### PR TITLE
Inline LcmSubscriber implementation

### DIFF
--- a/include/kodlab_mjbots_sdk/lcm_subscriber.h
+++ b/include/kodlab_mjbots_sdk/lcm_subscriber.h
@@ -106,16 +106,16 @@ class LcmSubscriber : public AbstractRealtimeObject {
 // Implementation                                                             //
 ////////////////////////////////////////////////////////////////////////////////
 
-LcmSubscriber::LcmSubscriber(int realtime_priority, int cpu) {
+inline LcmSubscriber::LcmSubscriber(int realtime_priority, int cpu) {
   cpu_ = cpu;
   realtime_priority_ = realtime_priority;
 }
 
-void LcmSubscriber::Init() {
+inline void LcmSubscriber::Init() {
   Start();
 }
 
-int LcmSubscriber::RemoveSubscription(const std::string &channel_name) {
+inline int LcmSubscriber::RemoveSubscription(const std::string &channel_name) {
   auto it = subs_.find(channel_name);
   if (it != subs_.end()) {
     int success = lcm_.unsubscribe(subs_[channel_name]);
@@ -128,7 +128,7 @@ int LcmSubscriber::RemoveSubscription(const std::string &channel_name) {
   return -1;
 }
 
-[[nodiscard]] const lcm::Subscription *LcmSubscriber::get_subscription(const std::string &channel_name) const {
+[[nodiscard]] inline const lcm::Subscription *LcmSubscriber::get_subscription(const std::string &channel_name) const {
   if (subs_.count(channel_name) == 1) {
     return subs_.at(channel_name);
   } else {
@@ -138,7 +138,7 @@ int LcmSubscriber::RemoveSubscription(const std::string &channel_name) {
   }
 }
 
-void LcmSubscriber::Run() {
+inline void LcmSubscriber::Run() {
   while (!CTRL_C_DETECTED) {
     lcm_.handleTimeout(1000);
   }


### PR DESCRIPTION
Currently, the `LcmSubscriber` implementation is in the `lcm_subscriber.h` header file where the class is defined.  If this file is included in multiple translation units, a linker error occurs due to multiple definitions of the member functions.  This will be fixed once the TODO in `lcm_subscriber.h` requesting that the implementation be moved to a `cpp` file is addressed.  However, this cannot happen until #51 is resolved.  This is a temporary fix to prevent linker errors in the meantime.