### PR TITLE
[RFC] Filter Development

### DIFF
--- a/include/kodlab_mjbots_sdk/filter.h
+++ b/include/kodlab_mjbots_sdk/filter.h
@@ -1,0 +1,43 @@
+/**
+ * @file filter.h
+ * @author Lucien C. Peach (peach@seas.upenn.edu)
+ * @brief Abstract base class for support of filter implementation. 
+ * @date 9/10/2022
+ * 
+ * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
+ * 
+ */
+
+#pragma once
+
+#include "Eigen/Geometry"
+
+namespace kodlab
+{
+
+class Filter {
+
+    public: 
+
+        // Pure virtual function for filter update calls
+        virtual Eigen::Vector3f Update(Eigen::Vector3f raw_data) = 0;
+
+        // Accessor for raw_data_
+        Eigen::Vector3f GetRawData() {
+            return raw_data_;
+        }
+
+        // Accessor for filtered_data_
+        Eigen::Vector3f GetFilteredData() {
+            return filtered_data_;
+        }
+
+   protected:
+
+        Eigen::Vector3f raw_data_;
+        Eigen::Vector3f filtered_data_;
+
+};
+
+} // kodlab::mjbots
+

--- a/include/kodlab_mjbots_sdk/low_pass_filter.h
+++ b/include/kodlab_mjbots_sdk/low_pass_filter.h
@@ -1,0 +1,67 @@
+/**
+ * @file low_pass_filter.h
+ * @author Lucien C. Peach (peach@seas.upenn.edu)
+ * @brief A discrete-time low-pass filter class.
+ * @date 9/10/2022
+ * 
+ * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
+ * 
+ */
+
+#pragma once
+
+#include "kodlab_mjbots_sdk/filter.h"
+#include "Eigen/Geometry"
+
+namespace kodlab
+{
+
+class LowPassFilter : public Filter {
+
+    public:
+
+        LowPassFilter(float dt, float k_frequency_cutoff, Eigen::Vector3f raw_data);
+
+        float FilterGain(const float k_frequency_cutoff);
+
+        Eigen::Vector3f Update(Eigen::Vector3f raw_data) override;
+
+        // Accessor for dt_
+        float GetDt() {
+            return dt_;
+        }
+
+        // Accessor for k_frequency_cutoff_
+        float GetCutoffFreq() {
+            return k_frequency_cutoff_;
+        }
+
+        // Accessor for alpha_
+        float GetAlpha() {
+            return alpha_;
+        }
+
+        
+    private:
+
+        float dt_;
+        float k_frequency_cutoff_;
+        float alpha_;
+
+};
+
+} //kodlab
+
+
+
+/* Notes for further additions
+
+//main.cpp
+
+LowPassFilter<Eigen::Vector3f> lpf  (dt, cutoff );
+while (True){
+    //DO STUFF
+    filt_data = lpf.Update(data);
+    
+    //DO STUFF
+} */

--- a/src/low_pass_filter.cpp
+++ b/src/low_pass_filter.cpp
@@ -1,0 +1,45 @@
+/**
+ * @file low_pass_filter.cpp
+ * @author Lucien C. Peach (peach@seas.upenn.edu)
+ * @brief Implementation of a discrete-time low-pass filter class.
+ * @date 9/10/2022
+ * 
+ * @copyright 2022 The Trustees of the University of Pennsylvania. All rights reserved.
+ * 
+ */
+
+#include "kodlab_mjbots_sdk/low_pass_filter.h"
+#include <math.h>
+#include <Eigen/Geometry>
+
+namespace kodlab
+{
+
+LowPassFilter::LowPassFilter(float dt, float k_frequency_cutoff, Eigen::Vector3f raw_data) {
+
+    dt_ = dt;
+    raw_data_ = raw_data;
+    filtered_data_ = raw_data;
+    k_frequency_cutoff_ = k_frequency_cutoff; 
+
+};
+
+float LowPassFilter::FilterGain(float k_frequency_cutoff_) {
+
+    float k_filter_time_constant = 1.0 / (2 * M_PI * k_frequency_cutoff_);
+
+    float alpha_ = dt_ / (k_filter_time_constant + dt_);
+
+}
+
+Eigen::Vector3f LowPassFilter::Update(Eigen::Vector3f raw_data) {
+
+    filtered_data_ = alpha_ * raw_data + (1 - alpha_) * filtered_data_;
+    raw_data = raw_data;
+    
+}
+
+// Future Version: Include Reinitialize / Set Filter Data: 
+
+} // kodlab
+


### PR DESCRIPTION
Introduces an abstract `Filter` class from which discrete-time filter implementations can be derived. Also provides several `Filter` implementation classes corresponding to various commonly used filter types.

This is a new feature. Addresses #62.

### Change List

- Provides `Filter` object, an abstract class for implementing discrete-time filtering. 
- Provides `LowPassFilter` object (a child of `Filter`), which implements a discrete time low-pass filter. 

### Upcoming Changes

- Inclusion of `DifferenceEquation` object (name subject to change) which will determine a LCCDE from Transfer Function polynomials.
- Will provide additional common filter implementation, facilitated by `DifferenceEquation`, including:
  - `HighPassFilter` object implementing a high-pass filter
  - `BandPassFilter` object implementing a band-pass filter
  - `BandStopFilter` object implementing a band-stop filter
  - `NotchFilter` object implementing a notch filter
- Improvements to generalizability.

### Potential (Long-Term) Future Changes
- Dynamic time step implementation.

### Testing

This PR draft has yet to be tested. Testing will be conducted by implementing the various filter implementations in the `SimpleControlIOExample` example behavior.

### Questions

Any feedback on how to improve or enhance the generalizability of this feature would be much appreciated. 
