### PR TITLE
Add the ability to send pd setpoints and pd scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the robot object as follows.
 class MyControlLoop : public kodlab::mjbots::MjbotsControlLoop
 {
   using MjbotsControlLoop::MjbotsControlLoop;
-  void CalcTorques() override{
+  void Update() override{
     std::vector<float> torques = control_effort;
     robot_->SetTorques(torques);
   }    
@@ -78,6 +78,31 @@ Next, implement the `ProcessInput` function to do things with the data in `lcm_s
       void ProcessInput()  override{
         gains_ = lcm_sub_.data_.gains;
       }
+
+## PD Set points and gains
+The SDK is built around just sending ffwd torque commands, but the moteus does have an onboard 
+PD loop. In order to use the built in PD loop modify the PD gains on the moteus. Next when setting
+up the control loop set:
+
+```
+kodlab::mjbots::ControlLoopOptions options;
+options.send_pd_commands = true;
+```
+By setting `send_pd_commands` to true the robot will now send pd scales and set points to the
+moteus. This will slow down the communication with the moteus, so only use this option if you
+are actually going to use the pd commands.
+
+In order to set the PD gains and set points next when constructing the joint vector set the value
+of `moteus_kp` and `moteus_kd` to the values configured on the moteus. Now in the update function
+you can use 
+
+```
+    robot_->joints[0]->set_joint_position_target(0);
+    robot_->joints[0]->set_joint_velocity_target(0);
+    robot_->joints[0]->set_kp(0.8);
+    robot_->joints[0]->set_kd(0.01);
+```
+to set gains and targets for the onboard pd loop.
 
 ## Robot Base
 The `RobotBase` object is intended to be inherited by a user-defined robot 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The SDK is built around just sending ffwd torque commands, but the moteus does h
 PD loop. In order to use the built in PD loop modify the PD gains on the moteus. Next when setting
 up the control loop set:
 
-```
+```cpp
 kodlab::mjbots::ControlLoopOptions options;
 options.send_pd_commands = true;
 ```

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -190,6 +190,12 @@ class JointBase {
          */
         const std::string get_name() const { return name_; }
 
+        /*!
+         * @brief get the torque limit for the servo
+         * @return torque limit for the servo
+         */
+        float get_servo_torque_limit() const {return max_torque_/gear_ratio_;};
+
     protected:
         std::string name_ = "";  // Optional joint name
         // Joint Params

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -196,7 +196,31 @@ class JointBase {
          */
         float get_servo_torque_limit() const {return max_torque_/gear_ratio_;};
 
-    protected:
+        /*!
+         * @brief set the joint position target in radians for the pd loop
+         * @param position_target target position in radians
+         */
+        void set_joint_position_target(float position_target){position_target_ = position_target;}
+
+        /*!
+         * @brief set the joint velocity target in radians/s for the pd loop
+         * @param velocity_target target velocity in rads/s
+         */
+        void set_joint_velocity_target(float velocity_target){position_target_ = velocity_target;}
+
+        /*!
+         * @brief set the kp for pd loop
+         * @param kp position gain in N m/rad
+         */
+        void set_kp(float kp){kp_ = kp;}
+
+        /*!
+         * @brief set the kd for pd loop
+         * @param kd velocity gain in N m s/rad
+         */
+        void set_kd(float kd){kd_ = kd;}
+
+ protected:
         std::string name_ = "";  // Optional joint name
         // Joint Params
         float gear_ratio_  = 1.0;   /// external joint gear ratio
@@ -207,6 +231,12 @@ class JointBase {
         float position_;    /// position of the joint [rad]
         float velocity_;    /// velocity of the joint [rad/s]
         float torque_ = 0;  /// Constrained torque for the joint [N m]
+
+        // PD setpoints and gain scales
+        float kp_ = 0;                ///< Value of kp for joint [N m / rad]
+        float kd_ = 0;                ///< Value of kd for joint [N m s/ rad]
+        float position_target_ = 0;   ///< Target joint position [rad]
+        float velocity_target_ = 0;   ///< Target joint velocity [rad/s]
 
         // Servo State/Commands (the raw motor values)
         float servo_position_;      /// position of the servo [rad]

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -30,6 +30,8 @@ struct MoteusJointConfig{
     float max_torque = std::numeric_limits<float>::infinity();
     float pos_min = -std::numeric_limits<float>::infinity();
     float pos_max = std::numeric_limits<float>::infinity();
+    float moteus_kp = 0;
+    float moteus_kd = 0;
 };
 
 /**         
@@ -52,6 +54,8 @@ class JointMoteus: public JointBase
          * @param max_torque    /// Maximum torque limit of the joint [N m] (Default:inf)
          * @param pos_min       /// Minimum joint pose limit before taking protective measures such as torque limiting or shut off (Default:-inf)
          * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
+         * @param moteus_kp     /// Value of kp set on moteus in units of N m/rev
+         * @param moteus_kd     /// Value of kd set on moteus in units of N m s/rev
          */
         JointMoteus(
             std::string name,
@@ -62,9 +66,14 @@ class JointMoteus: public JointBase
             float gear_ratio = 1.0,
             float max_torque = std::numeric_limits<float>::infinity(),
             float pos_min = -std::numeric_limits<float>::infinity(),
-            float pos_max = std::numeric_limits<float>::infinity())
+            float pos_max = std::numeric_limits<float>::infinity(),
+            float moteus_kp = 0,
+            float moteus_kd = 0)
             : JointBase(name, direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
-              can_bus_(can_bus), can_id_(can_id) {}
+              can_bus_(can_bus),
+              can_id_(can_id),
+              moteus_kp_(moteus_kp),
+              moteus_kd_(moteus_kd)  {}
 
         /**
          * @brief Construct a new Joint Moteus object without name
@@ -77,6 +86,8 @@ class JointMoteus: public JointBase
          * @param max_torque    /// Maximum torque limit of the joint [N m] (Default:inf)
          * @param pos_min       /// Minimum joint pose limit before taking protective measures such as torque limiting or shut off (Default:-inf)
          * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
+         * @param moteus_kp     /// Value of kp set on moteus in units of N m/rev
+         * @param moteus_kd     /// Value of kd set on moteus in units of N m s/rev
          */
         JointMoteus(
             int can_id,
@@ -86,9 +97,14 @@ class JointMoteus: public JointBase
             float gear_ratio = 1.0,
             float max_torque = std::numeric_limits<float>::infinity(),
             float pos_min = -std::numeric_limits<float>::infinity(),
-            float pos_max = std::numeric_limits<float>::infinity())
+            float pos_max = std::numeric_limits<float>::infinity(),
+            float moteus_kp = 0,
+            float moteus_kd = 0)
             : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
-              can_bus_(can_bus), can_id_(can_id) {}
+              can_bus_(can_bus),
+              can_id_(can_id),
+              moteus_kp_(moteus_kp),
+              moteus_kd_(moteus_kd) {}
 
 
         /**
@@ -105,7 +121,9 @@ class JointMoteus: public JointBase
                          config.pos_min,
                          config.pos_max),
               can_id_( config.can_id),
-              can_bus_( config.can_bus) {}
+              can_bus_( config.can_bus),
+              moteus_kp_(config.moteus_kp),
+              moteus_kd_(config.moteus_kd){}
         
         /**
          * @brief Update the joint of the moteus. Converts rot/s to rad/s and saves mode
@@ -141,66 +159,40 @@ class JointMoteus: public JointBase
         const ::mjbots::moteus::Mode & get_mode_reference()   const {return mode_; }
 
         /*!
-         * @brief Set the kp_scale for the moteus
-         * @param kp_scale limited between 0 and 1
-         */
-        void set_kp_scale(float kp_scale){
-          if(kp_scale > 1){
-            LOG_WARN("kp_scale is greater than 1, will be limited to 1");
-          }
-          kp_scale = kp_scale;
-        }
-
-        /*!
-         * @brief Set the kd_scale for the moteus
-         * @param kd_scale limited between 0 and 1
-         */
-        void set_kd_scale(float kd_scale){
-          if(kd_scale > 1){
-            LOG_WARN("kd_scale is greater than 1, will be limited to 1");
-          }
-          kd_scale_ = kd_scale;
-        }
-
-        /*!
-         * @brief set the joint position target in radians for the pd loop
-         * @param position_target target position in radians
-         */
-        void set_joint_position_target(float position_target){
-          position_target_ = position_target;
-        }
-
-       /*!
-        * @brief set the joint velocity target in radians/s for the pd loop
-        * @param velocity_target target velocity in rads/s
-        */
-        void set_joint_velocity_target(float velocity_target){
-          position_target_ = velocity_target;
-        }
-
-        /*!
          * @brief accessor for kp_scale
          * @return kp_scale
          */
-        [[nodiscard]] float get_kp_scale() const {return kp_scale_;}
+        [[nodiscard]] float get_kp_scale() const {
+          if(moteus_kp_ == 0){
+            LOG_WARN("Moteus kp is set to 0, while attempting to send pd commands");
+            return 0;
+          }
+          // Multiply by 2pi to convert kp from radians to revolutions
+          // Divide by gear ratio to get servo kp rather than joint kp
+          const float kp_scale = kp_/moteus_kp_ * 2 * M_PI/gear_ratio_;
+          if(kp_scale > 1){
+            LOG_WARN("kp_scale is greater than 1, will be limited to 1. Either use a lower kp or increase kp in the moteus");
+            LOG_WARN("With the current moteus kp of %.3f, the max value of the joint kp is %.3f", moteus_kp_, kp_/kp_scale);
+          }
+          return kp_scale;
+        }
 
         /*!
          * @brief accessor for kd_scale
          * @return kd_scale
          */
-        [[nodiscard]] float get_kd_scale() const {return kd_scale_;}
-
-        /*!
-         * @brief accessor for joint position target
-         * @return joint position target in rad
-         */
-        [[nodiscard]] float get_joint_position_target()const{return position_target_;}
-
-        /*!
-         * @brief accessor for joint velocity target
-         * @return joint_velociyt target in radians/s
-         */
-        [[nodiscard]] float get_joint_velocity_target()const{return velocity_target_;}
+        [[nodiscard]] float get_kd_scale() const {
+          if(moteus_kd_ == 0){
+            LOG_WARN("Moteus kd is set to 0, while attempting to send pd commands");
+            return 0;
+          }
+          const float kd_scale = kd_/moteus_kd_ * 2 * M_PI/gear_ratio_;
+          if(kd_scale > 1){
+            LOG_WARN("kd_scale is greater than 1, will be limited to 1. Either use a lower kd or increase kd in the moteus");
+            LOG_WARN("With the current moteus kd of %.3f, the max value of the joint kd is %.3f", moteus_kp_, kd_/kd_scale);
+          }
+          return kd_scale;
+        }
 
         /*!
          * @brief accessor for the moteus position target
@@ -219,12 +211,8 @@ class JointMoteus: public JointBase
         int can_id_;   /// the can id of this joint's moteus
         int can_bus_;  /// the can bus the moteus communicates on
         ::mjbots::moteus::Mode mode_ = ::mjbots::moteus::Mode::kStopped; /// joint's moteus mode
-
-        // PD setpoints and gain scales
-        float kp_scale_ = 0;          ///< kp scale, limited between 0 and 1
-        float kd_scale_ = 0;          ///< kd scale, limited between 0 and 1
-        float position_target_ = 0;   ///< Target joint position
-        float velocity_target_ = 0;   ///< Target joint velocity
+        float moteus_kp_ = 0;
+        float moteus_kd_ = 0;
 };
 }//namespace mjbots
 }//namespace kodlab

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "kodlab_mjbots_sdk/joint_base.h"
 #include "kodlab_mjbots_sdk/moteus_protocol.h"
+#include "kodlab_mjbots_sdk/log.h"
 #include <string>
 
 namespace kodlab{
@@ -139,10 +140,91 @@ class JointMoteus: public JointBase
          */
         const ::mjbots::moteus::Mode & get_mode_reference()   const {return mode_; }
 
+        /*!
+         * @brief Set the kp_scale for the moteus
+         * @param kp_scale limited between 0 and 1
+         */
+        void set_kp_scale(float kp_scale){
+          if(kp_scale > 1){
+            LOG_WARN("kp_scale is greater than 1, will be limited to 1");
+          }
+          kp_scale = kp_scale;
+        }
+
+        /*!
+         * @brief Set the kd_scale for the moteus
+         * @param kd_scale limited between 0 and 1
+         */
+        void set_kd_scale(float kd_scale){
+          if(kd_scale > 1){
+            LOG_WARN("kd_scale is greater than 1, will be limited to 1");
+          }
+          kd_scale_ = kd_scale;
+        }
+
+        /*!
+         * @brief set the joint position target in radians for the pd loop
+         * @param position_target target position in radians
+         */
+        void set_joint_position_target(float position_target){
+          position_target_ = position_target;
+        }
+
+       /*!
+        * @brief set the joint velocity target in radians/s for the pd loop
+        * @param velocity_target target velocity in rads/s
+        */
+        void set_joint_velocity_target(float velocity_target){
+          position_target_ = velocity_target;
+        }
+
+        /*!
+         * @brief accessor for kp_scale
+         * @return kp_scale
+         */
+        [[nodiscard]] float get_kp_scale() const {return kp_scale_;}
+
+        /*!
+         * @brief accessor for kd_scale
+         * @return kd_scale
+         */
+        [[nodiscard]] float get_kd_scale() const {return kd_scale_;}
+
+        /*!
+         * @brief accessor for joint position target
+         * @return joint position target in rad
+         */
+        [[nodiscard]] float get_joint_position_target()const{return position_target_;}
+
+        /*!
+         * @brief accessor for joint velocity target
+         * @return joint_velociyt target in radians/s
+         */
+        [[nodiscard]] float get_joint_velocity_target()const{return velocity_target_;}
+
+        /*!
+         * @brief accessor for the moteus position target
+         * @return the moteus position target in units of revolutions
+         */
+        [[nodiscard]] float get_moteus_position_target()const{return (position_target_ + zero_offset_) * gear_ratio_/direction_/2/M_PI;}
+
+        /*!
+         * @brief accessor for the moteus velocity target
+         * @return the moteus velocity target in units of revolutions/s
+         */
+        [[nodiscard]] float get_moteus_velocity_target()const{return (velocity_target_) * gear_ratio_/direction_/2/M_PI;}
+
+
     private:
         int can_id_;   /// the can id of this joint's moteus
         int can_bus_;  /// the can bus the moteus communicates on
         ::mjbots::moteus::Mode mode_ = ::mjbots::moteus::Mode::kStopped; /// joint's moteus mode
+
+        // PD setpoints and gain scales
+        float kp_scale_ = 0;          ///< kp scale, limited between 0 and 1
+        float kd_scale_ = 0;          ///< kd scale, limited between 0 and 1
+        float position_target_ = 0;   ///< Target joint position
+        float velocity_target_ = 0;   ///< Target joint velocity
 };
 }//namespace mjbots
 }//namespace kodlab

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -41,7 +41,8 @@ struct ControlLoopOptions {
   int attitude_rate_hz = 1000;              /// Frequency of the imu updates from the pi3hat. Options are limited to 1000
                                             /// 400, 200, 100.
   bool dry_run = false;  ///< If true, torques sent to moteus boards will always be zero
-  bool print_torques = false;  ///< If true, torque commandss will be printed to console
+  bool print_torques = false;  ///< If true, torque commands will be printed to console
+  bool send_pd_commands = false; ///< If true, the control loop will send pd setpoints & gains in addition to ffwd torque commands
 };
 
 /*!
@@ -192,7 +193,8 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shar
       options.imu_mounting_deg, options.attitude_rate_hz,
       robot_->GetIMUDataSharedPtr(), options.imu_world_offset_deg,
       options.dry_run,
-      options.print_torques);
+      options.print_torques,
+      options.send_pd_commands);
   num_joints_ = robot_->joints.size();
   SetupOptions(options);
 }

--- a/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
+++ b/include/kodlab_mjbots_sdk/mjbots_hardware_interface.h
@@ -49,6 +49,7 @@ class MjbotsHardwareInterface  {
    * @param imu_world_offset_deg [Optional] IMU orientation offset. Useful for re-orienting gravity, etc.
    * @param dry_run if true, sends zero-torques to Moteus controllers
    * @param print_torques if true, prints torque commands
+   * @param send_pd_commands if true, packets to the moteus include pd gains and setpoints
    */
   MjbotsHardwareInterface(std::vector<std::shared_ptr<JointMoteus>> joint_list,
                        const RealtimeParams &realtime_params,
@@ -57,7 +58,8 @@ class MjbotsHardwareInterface  {
                        std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr,
                        std::optional<::mjbots::pi3hat::Euler > imu_world_offset_deg = std::nullopt,
                        bool dry_run = false,
-                       bool print_torques = false
+                       bool print_torques = false,
+                       bool send_pd_commands = false
                        );
 
   /**
@@ -126,6 +128,7 @@ class MjbotsHardwareInterface  {
   u_int64_t cycle_count_ = 0;                        /// Number of cycles/commands sent
   bool dry_run_;                                     ///< dry run active flag
   bool print_torques_;                               ///< print torques active flag
+  bool send_pd_commands_;                            ///< Include pd gains and setpoints in the moteus packet
 
   std::map<int, int> servo_bus_map_;       /// map from servo id to servo bus
 

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -20,12 +20,21 @@ void MjbotsHardwareInterface::InitializeCommand() {
   }
 
   ::mjbots::moteus::PositionResolution res; // This is just for the command
-  res.position = ::mjbots::moteus::Resolution::kIgnore;
-  res.velocity = ::mjbots::moteus::Resolution::kIgnore;
-  res.feedforward_torque = ::mjbots::moteus::Resolution::kInt16;
-  res.kp_scale = ::mjbots::moteus::Resolution::kIgnore;
-  res.kd_scale = ::mjbots::moteus::Resolution::kIgnore;
-  res.maximum_torque = ::mjbots::moteus::Resolution::kIgnore;
+  if(send_pd_commands_){
+    res.position = ::mjbots::moteus::Resolution::kInt16;
+    res.velocity = ::mjbots::moteus::Resolution::kInt16;
+    res.feedforward_torque = ::mjbots::moteus::Resolution::kInt16;
+    res.kp_scale = ::mjbots::moteus::Resolution::kInt16;
+    res.kd_scale = ::mjbots::moteus::Resolution::kInt16;
+    res.maximum_torque = ::mjbots::moteus::Resolution::kInt8;
+  }else{
+    res.position = ::mjbots::moteus::Resolution::kIgnore;
+    res.velocity = ::mjbots::moteus::Resolution::kIgnore;
+    res.feedforward_torque = ::mjbots::moteus::Resolution::kInt16;
+    res.kp_scale = ::mjbots::moteus::Resolution::kIgnore;
+    res.kd_scale = ::mjbots::moteus::Resolution::kIgnore;
+    res.maximum_torque = ::mjbots::moteus::Resolution::kIgnore;
+  }
   res.stop_position = ::mjbots::moteus::Resolution::kIgnore;
   res.watchdog_timeout = ::mjbots::moteus::Resolution::kIgnore;
   for (auto &cmd : commands_) {
@@ -131,6 +140,13 @@ void MjbotsHardwareInterface::SendCommand() {
 
   for (int servo = 0; servo < num_joints_; servo++) {// TODO Move to a seperate update method (allow non-ff torque commands)?
     commands_[servo].position.feedforward_torque = (dry_run_ ? 0 : joints[servo]->get_servo_torque());
+    if(send_pd_commands_){
+      commands_[servo].position.position = joints[servo]->get_moteus_position_target();
+      commands_[servo].position.velocity = joints[servo]->get_moteus_velocity_target();
+      commands_[servo].position.kp_scale = joints[servo]->get_kp_scale();
+      commands_[servo].position.kd_scale = joints[servo]->get_kd_scale();
+      commands_[servo].position.maximum_torque = joints[servo]->get_servo_torque_limit();
+    }
   }
   if (print_torques_) {
     std::vector<float> vec;

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -57,10 +57,12 @@ MjbotsHardwareInterface::MjbotsHardwareInterface(std::vector<std::shared_ptr<Joi
                                                  std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr,
                                                  std::optional<::mjbots::pi3hat::Euler> imu_world_offset_deg,
                                                  bool dry_run,
-                                                 bool print_torques)
+                                                 bool print_torques,
+                                                 bool send_pd_commands)
     : imu_data_(imu_data_ptr ? imu_data_ptr : std::make_shared<::kodlab::IMUData<float>>()),
       dry_run_(dry_run),
-      print_torques_(print_torques)
+      print_torques_(print_torques),
+      send_pd_commands_(send_pd_commands)
 { 
   LOG_IF_WARN(dry_run_, "\nDRY RUN: NO TORQUES COMMANDED");
   joints = joint_ptrs;


### PR DESCRIPTION
We have wanted the ability to use the moteus's internal pd loop for a long time. This PR should enable us to send PD setpoints and to use the kp and kd scale to control the moteus. 

One gotcha with the way moteus does its internal pd loop is that you can't set the gains over CAN, you can only set the scale of the gain (0-1), which means that the configuration of the moteus becomes more important. 


# Todo

- [x] Create example
- [x] Test on hardware