### PR TITLE
Enabled dry run and stop for pd commands

### DIFF
--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -94,7 +94,13 @@ namespace kodlab
          * @brief Stop the robot by setting torques to zero. Can be overridden
          *        if other features are available e.g. mehanical or regen braking
          */
-        virtual void Stop(){SetTorques(std::vector<float>(num_joints_, 0));}
+        virtual void Stop(){
+          SetTorques(std::vector<float>(num_joints_, 0));
+          for(const auto& joint: joints){
+            joint->set_kp(0);
+            joint->set_kd(0);
+          }
+        }
 
         /*!
          * @brief accessor for joint positions, takes into account direction and offset

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -143,8 +143,8 @@ void MjbotsHardwareInterface::SendCommand() {
     if(send_pd_commands_){
       commands_[servo].position.position = joints[servo]->get_moteus_position_target();
       commands_[servo].position.velocity = joints[servo]->get_moteus_velocity_target();
-      commands_[servo].position.kp_scale = joints[servo]->get_kp_scale();
-      commands_[servo].position.kd_scale = joints[servo]->get_kd_scale();
+      commands_[servo].position.kp_scale = dry_run_ ? 0 : joints[servo]->get_kp_scale();
+      commands_[servo].position.kd_scale = dry_run_ ? 0 : joints[servo]->get_kd_scale();
       commands_[servo].position.maximum_torque = joints[servo]->get_servo_torque_limit();
     }
   }


### PR DESCRIPTION
I realized that in #71 I didn't properly hook up the PD commands to the dry run flag and the stop function in RobotBase. This PR fixes that.