### PR TITLE
Added joint torque measurments

### DIFF
--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -74,8 +74,9 @@ class JointBase {
          * 
          * @param servo_pos raw servo position
          * @param servo_vel raw servo velocity
+         * @param servo_torque raw servo torque measurement
          */
-        virtual void UpdateState(float servo_pos, float servo_vel);
+        virtual void UpdateState(float servo_pos, float servo_vel, float servo_torque);
 
         /**
          * @brief Calculate and limit torque and set servo torque_cmd_
@@ -140,6 +141,13 @@ class JointBase {
          * @return float 
          */
         virtual float get_servo_torque() const {return servo_torque_;}
+
+        /**
+         * @brief Get the measured joint torque
+         *
+         * @return float
+         */
+        virtual float get_measured_torque() const {return measured_torque_;}
 
         /**
          * @brief Set the soft stop flag
@@ -231,6 +239,7 @@ class JointBase {
         float position_;    /// position of the joint [rad]
         float velocity_;    /// velocity of the joint [rad/s]
         float torque_ = 0;  /// Constrained torque for the joint [N m]
+        float measured_torque_ = 0;  /// Measured joint torque [N m]
 
         // PD setpoints and gain scales
         float kp_ = 0;                ///< Value of kp for joint [N m / rad]
@@ -242,6 +251,7 @@ class JointBase {
         float servo_position_;      /// position of the servo [rad]
         float servo_velocity_;      /// velocity of the servo [rad/s]
         float servo_torque_ = 0;    /// torque command for servo [N m]
+        float measured_servo_torque_ = 0;  /// Measured servo torque [N m]
 
         // Features
         bool  soft_stop_active_ = true;  /// enable soft stop flag 

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -130,10 +130,11 @@ class JointMoteus: public JointBase
          * 
          * @param reply_pos position reported by moteus [rot]
          * @param reply_vel velocity reported by moteus [rot/s]
+         * @param reply_torque torque measured by the moteus [Nm]
          * @param mode      moteus mode
          */
-        void UpdateMoteus(float reply_pos, float reply_vel, ::mjbots::moteus::Mode mode ){
-            UpdateState( 2 * M_PI * reply_pos, 2 * M_PI * reply_vel );
+        void UpdateMoteus(float reply_pos, float reply_vel, float reply_torque, ::mjbots::moteus::Mode mode ){
+            UpdateState( 2 * M_PI * reply_pos, 2 * M_PI * reply_vel, reply_torque);
             mode_ = mode;
         }
 

--- a/src/joint_base.cpp
+++ b/src/joint_base.cpp
@@ -65,11 +65,13 @@ float JointBase::UpdateTorque(float joint_torque){
     return servo_torque_;
 }
 
-void JointBase::UpdateState(float servo_pos, float servo_vel){  
+void JointBase::UpdateState(float servo_pos, float servo_vel, float servo_torque){
     servo_position_ = servo_pos;
     servo_velocity_ = servo_vel;
-    position_ = direction_ * servo_pos / gear_ratio_ - zero_offset_ ; 
+    measured_servo_torque_ = servo_torque;
+    position_ = direction_ * servo_pos / gear_ratio_ - zero_offset_ ;
     velocity_= direction_ * servo_vel / gear_ratio_ ;
+    measured_torque_ = direction_ * servo_torque * gear_ratio_;
 }
 
 } // kodlab

--- a/src/mjbots_hardware_interface.cpp
+++ b/src/mjbots_hardware_interface.cpp
@@ -40,6 +40,9 @@ void MjbotsHardwareInterface::InitializeCommand() {
   for (auto &cmd : commands_) {
     cmd.resolution = res;
     cmd.mode = ::mjbots::moteus::Mode::kStopped;
+    if(send_pd_commands_){
+      cmd.query.torque = ::mjbots::moteus::Resolution::kInt16;
+    }
   }
 }
 
@@ -129,7 +132,8 @@ void MjbotsHardwareInterface::ProcessReply() {
     if(std::isnan(servo_reply.position)){
       std::cout<<"Missing can frame for servo: " << joint->get_can_id()<< std::endl;
     } else{
-      joint->UpdateMoteus(servo_reply.position, servo_reply.velocity, servo_reply.mode);
+      joint->UpdateMoteus(servo_reply.position, servo_reply.velocity,
+                          send_pd_commands_ ? servo_reply.torque : 0,servo_reply.mode);
     }
   }
   imu_data_->Update(*(moteus_data_.attitude));


### PR DESCRIPTION
Adds the ability to access moteus measured torque at the sdk level. This is helpful when using the moteus pd loop and could be used to detect cases where the moteus is running into the speed torque curve.