### PR TITLE
Changed to joint level soft start

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ An example demonstrating usage of the `MjbotsBehaviorLoop` is provided in
 `examples/behavior_robot_example.cpp`.
 
 ## Soft Start
-To configure the soft Start, set the `options.max_torque` and `options.soft_start_duration`. Where the
-max torque is the maximum torque per motor and the soft Start duration is how long the torque ramp should last
-in iterations of the control loop. 
+Each joint has its own soft start. To configure the soft start set the `MoteusJointConfig.max_torque`
+to the maximum allowable torque for the motor and `MoteusJointConfig.soft_start_duration_ms` to the
+duration of the soft start. The soft start will ramp the maximum torque from 0 to `max_torque` over `soft_start_duration_ms`.
+Once the time is greater than `soft_start_duration_ms`, torque will be limited to `max_torque`.
 
 ## Console Logging
 The `log.h` header provides a set of debug logging macros with adjustable

--- a/examples/behavior_robot_example.cpp
+++ b/examples/behavior_robot_example.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 {
   // Setup joints with a std::vector
   std::vector<kodlab::mjbots::JointMoteus> joints;
-  joints.emplace_back(22, 1, 1, 0, 1.0, 5.0);
+  joints.emplace_back(22, 1, 1, 0, 1.0, 1.0);
 
   // Define robot options
   kodlab::mjbots::ControlLoopOptions options;
@@ -91,7 +91,6 @@ int main(int argc, char **argv)
   options.frequency = 1000;  // control loop frequency
   options.realtime_params.main_cpu = 3;
   options.realtime_params.can_cpu = 2;
-  options.max_torque = 1.0;
 
   // Create control loop
   SimpleRobotBehaviorLoop simple_robot(joints, options);

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -163,7 +163,6 @@ int main(int argc, char **argv) {
   kodlab::mjbots::ControlLoopOptions options;
   options.log_channel_name = "leg_data";
   options.input_channel_name = "leg_gains";
-  options.soft_start_duration_ms = 5000;
 
   // Create control loop
   Hopping control_loop(std::move(joints), options);

--- a/examples/leg_2DoF_example.cpp
+++ b/examples/leg_2DoF_example.cpp
@@ -58,7 +58,7 @@ class Hopping : public kodlab::mjbots::MjbotsControlLoop<LegLog, LegGains> {
         // In flight we use pd loops to control in limb space
         f_z_ = k_stiff_ * (z0_ - z_) - b_stiff_ * d_z_;
         // We Constrain f_x to prevent large jumps in x force
-        f_x_ = kodlab::SoftStart::Constrain(-kp_ * x_ - kd_ * d_x_, -kMaxF_x, kMaxF_x);
+        f_x_ = kodlab::TorqueLimiter::Constrain(-kp_ * x_ - kd_ * d_x_, -kMaxF_x, kMaxF_x);
 
         // convert from limb space to joint space
         torques = leg_.InverseDynamics(robot_->GetJointPositions(), f_z_, f_x_);

--- a/examples/spin_joints_example.cpp
+++ b/examples/spin_joints_example.cpp
@@ -45,9 +45,24 @@ class Spin_Joint : public kodlab::mjbots::MjbotsControlLoop<ManyMotorLog> {
 int main(int argc, char **argv) {
   //Setup joints
   std::vector<kodlab::mjbots::JointMoteus> joints;
-  joints.emplace_back(100, 4, 1, -1.3635165,   1, 1);
-  joints.emplace_back(101, 4,-1,  2.688, 5.0/3.0, 1);
-  joints.emplace_back(108, 4, 1, -0.4674585,   1, 1);
+  joints.emplace_back(100,
+                      4,
+                      1,
+                      -1.3635165,
+                      1,
+                      1,
+                      -std::numeric_limits<float>::infinity(),
+                      std::numeric_limits<float>::infinity(),
+                      10000);
+  joints.emplace_back(101,
+                      4,
+                      -1,
+                      2.688,
+                      1,
+                      1,
+                      -std::numeric_limits<float>::infinity(),
+                      std::numeric_limits<float>::infinity(),
+                      10000);
 
   // Define robot options
   kodlab::mjbots::ControlLoopOptions options;

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -180,7 +180,7 @@ class JointBase {
          * 
          * @return const float& 
          */
-        const float& get_servo_torque_reference() const {return servo_torque_; }
+        const float& get_torque_cmd_reference() const {return torque_; }
 
         /**
          * @brief Get the minimum position limit

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <type_traits>
 #include <string>
+#include "kodlab_mjbots_sdk/soft_start.h"
 
 namespace kodlab
 {
@@ -39,6 +40,7 @@ class JointBase {
          * @param max_torque    /// Maximum torque of the joint [N m] (Default:inf)
          * @param pos_min       /// Minimum joint limit before taking protective measures such as torque limiting or shut off (Default:inf)
          * @param pos_max       /// Maximum joint limit before taking protective measures such as torque limiting or shut off (Default:-inf)
+         * @param soft_start_duration_ms /// Duration of torque limit ramp (soft start) in ms
          */
         JointBase(
                 std::string name,
@@ -47,7 +49,8 @@ class JointBase {
                 float gear_ratio = 1.0, 
                 float max_torque = std::numeric_limits<float>::infinity(),
                 float pos_min = -std::numeric_limits<float>::infinity(), 
-                float pos_max = std::numeric_limits<float>::infinity()
+                float pos_max = std::numeric_limits<float>::infinity(),
+                float soft_start_duration_ms = 1
                 );
 
         /**
@@ -59,6 +62,7 @@ class JointBase {
          * @param max_torque    /// Maximum torque of the joint [N m] (Default:inf)
          * @param pos_min       /// Minimum joint limit before taking protective measures such as torque limiting or shut off (Default:inf)
          * @param pos_max       /// Maximum joint limit before taking protective measures such as torque limiting or shut off (Default:-inf)
+         * @param soft_start_duration_ms /// Duration of torque limit ramp (soft start) in ms
          */
         JointBase(
                 int direction = 1, 
@@ -66,8 +70,9 @@ class JointBase {
                 float gear_ratio = 1.0, 
                 float max_torque = std::numeric_limits<float>::infinity(),
                 float pos_min = -std::numeric_limits<float>::infinity(), 
-                float pos_max = std::numeric_limits<float>::infinity()
-                );
+                float pos_max = std::numeric_limits<float>::infinity(),
+                float soft_start_duration_ms = 1
+        );
 
         /**
          * @brief Update position and velocity using all the servo params (gear ratio, offset, direction)
@@ -261,6 +266,8 @@ class JointBase {
         float pos_limit_min_ = -std::numeric_limits<float>::infinity(); /// max position [rad] before soft stop
         float pos_limit_max_ =  std::numeric_limits<float>::infinity(); /// min position [rad] before soft stop
 
+        // Soft start
+        SoftStart soft_start_;
 };
 
 

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -32,6 +32,7 @@ struct MoteusJointConfig{
     float pos_max = std::numeric_limits<float>::infinity();
     float moteus_kp = 0;
     float moteus_kd = 0;
+    float soft_start_duration_ms = 1;
 };
 
 /**         
@@ -56,6 +57,7 @@ class JointMoteus: public JointBase
          * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
          * @param moteus_kp     /// Value of kp set on moteus in units of N m/rev
          * @param moteus_kd     /// Value of kd set on moteus in units of N m s/rev
+         * @param soft_start_duration_ms /// Duration of torque limit ramp (soft start) in ms
          */
         JointMoteus(
             std::string name,
@@ -67,9 +69,10 @@ class JointMoteus: public JointBase
             float max_torque = std::numeric_limits<float>::infinity(),
             float pos_min = -std::numeric_limits<float>::infinity(),
             float pos_max = std::numeric_limits<float>::infinity(),
+            float soft_start_duration_ms = 1,
             float moteus_kp = 0,
             float moteus_kd = 0)
-            : JointBase(name, direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
+            : JointBase(name, direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max, soft_start_duration_ms),
               can_bus_(can_bus),
               can_id_(can_id),
               moteus_kp_(moteus_kp),
@@ -88,6 +91,7 @@ class JointMoteus: public JointBase
          * @param pos_max       /// Maximum joint pose limit before taking protective measures such as torque limiting or shut off (Default:inf)
          * @param moteus_kp     /// Value of kp set on moteus in units of N m/rev
          * @param moteus_kd     /// Value of kd set on moteus in units of N m s/rev
+         * @param soft_start_duration_ms /// Duration of torque limit ramp (soft start) in ms
          */
         JointMoteus(
             int can_id,
@@ -98,9 +102,10 @@ class JointMoteus: public JointBase
             float max_torque = std::numeric_limits<float>::infinity(),
             float pos_min = -std::numeric_limits<float>::infinity(),
             float pos_max = std::numeric_limits<float>::infinity(),
+            float soft_start_duration_ms = 1,
             float moteus_kp = 0,
             float moteus_kd = 0)
-            : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max),
+            : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max, soft_start_duration_ms),
               can_bus_(can_bus),
               can_id_(can_id),
               moteus_kp_(moteus_kp),

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -251,6 +251,7 @@ void MjbotsControlLoop<log_type, input_type, robot_type>::Run() {
   robot_->Init();
   lcm_sub_->Init();
   Init();
+  SoftStart::InitializeTimer();
 
   float prev_msg_duration = 0;
 

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -27,8 +27,6 @@ namespace kodlab::mjbots {
 struct ControlLoopOptions {
   RealtimeParams realtime_params;  /// Set of parameters for robot's realtimeness
 
-  float max_torque = 20;             /// Maximum torque in Nm
-  float soft_start_duration_ms = 1000;    /// Duration of the soft Start in ms
   int frequency = 1000;              /// Frequency of the control loop in Hz
   std::string log_channel_name;         /// LCM channel name for logging data. Leave empty to not log
   std::string input_channel_name;       /// LCM channel name for input data. Leave empty to not use input
@@ -169,7 +167,7 @@ MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::vect
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(
     std::vector<std::shared_ptr<kodlab::mjbots::JointMoteus>> joint_ptrs, const ControlLoopOptions &options)
-  : MjbotsControlLoop(std::make_shared<robot_type>(joint_ptrs, options.max_torque, options.soft_start_duration_ms),options) {}
+  : MjbotsControlLoop(std::make_shared<robot_type>(joint_ptrs),options) {}
 
 template<class log_type, class input_type, class robot_type>
 MjbotsControlLoop<log_type, input_type, robot_type>::MjbotsControlLoop(std::shared_ptr<robot_type>robot_in, const ControlLoopOptions &options)

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -38,10 +38,7 @@ namespace kodlab
          */
         template <class JointDerived = JointBase>
         RobotBase(std::vector<std::shared_ptr<JointDerived>> joint_vect,
-                  float robot_max_torque,
-                  float soft_start_duration_ms,
                   std::shared_ptr<::kodlab::IMUData<float>> imu_data_ptr = nullptr)
-            : soft_start_(robot_max_torque, soft_start_duration_ms)
         {
             // Ensure at compile time that the template is JointBase or a child of JointBase
             static_assert(std::is_base_of<JointBase, JointDerived>::value);
@@ -51,7 +48,7 @@ namespace kodlab
                 joints.push_back(j); // Copy constructed, uses an implicit upcasting
                 positions_.push_back( j->get_position_reference() );
                 velocities_.push_back( j->get_velocity_reference() );
-                torque_cmd_.push_back( j->get_servo_torque_reference() );
+                torque_cmd_.push_back(j->get_torque_cmd_reference() );
                 if(j->get_name() != ""){
                   if (!joint_name_to_index_.insert({j->get_name(), joints.size()-1}).second){
                     LOG_ERROR("Duplicate non empty joint names for name: %s", j->get_name().c_str());
@@ -188,7 +185,6 @@ namespace kodlab
         std::vector<std::reference_wrapper<const float>> torque_cmd_; /// Vector of the torque command sent to motors (references to the members of joints_)
         std::shared_ptr<::kodlab::IMUData<float>> imu_data_;          /// Robot IMU data
         real_time_tools::Timer run_timer_;                            /// Run timer for robot, started at construction
-        SoftStart soft_start_;                                        /// Soft Start object
         int num_joints_ = 0;                                          /// Number of joints
         std::unordered_map<std::string, int> joint_name_to_index_;    ///< Map from joint name to joint index
     };

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -48,7 +48,7 @@ namespace kodlab
                 joints.push_back(j); // Copy constructed, uses an implicit upcasting
                 positions_.push_back( j->get_position_reference() );
                 velocities_.push_back( j->get_velocity_reference() );
-                torque_cmd_.push_back(j->get_torque_cmd_reference() );
+                torque_cmd_.push_back( j->get_torque_cmd_reference() );
                 if(j->get_name() != ""){
                   if (!joint_name_to_index_.insert({j->get_name(), joints.size()-1}).second){
                     LOG_ERROR("Duplicate non empty joint names for name: %s", j->get_name().c_str());

--- a/include/kodlab_mjbots_sdk/soft_start.h
+++ b/include/kodlab_mjbots_sdk/soft_start.h
@@ -8,6 +8,7 @@
 #pragma once
 #include <vector>
 #include <cmath>
+#include "real_time_tools/timer.hpp"
 
 namespace kodlab {
 /*!
@@ -18,33 +19,21 @@ class SoftStart {
   float slope_ = 0;        /// Slope of the ramp
   float max_torque_ = 100; /// Max torque allowed in Nm
   float duration_ms_ = 0;   /// Duration of soft start in milliseconds
-
+  static real_time_tools::Timer timer_;
+  static bool timer_initialized_;
  public:
 
   /*!
    * @brief constrains the vector torques based on soft Start
    * @param torques[in, out] the torques to be constrained
-   * @param time_since_start_ms the number of milliseconds it has been since
-   * start
    */
-  void ConstrainTorques(std::vector<float> &torques, float time_since_start_ms);
+  void ConstrainTorques(std::vector<float> &torques) const;
 
   /*!
-   * @brief constrains all values in values between min_val and max_val
-   * @param values[in, out] vector to be constrained
-   * @param min_val minimum value allowed in vector
-   * @param max_val maximum value allowed in vector
-   */
-  static void Constrain(std::vector<float> &values, float min_val, float max_val);
-
-  /*!
-   * @brief constrains a single value between min_val and max_val
-   * @param values[in]
-   * @param min_val minimum value allowed
-   * @param max_val maximum value allowed
-   * @return constrained value
-   */
-  static float Constrain(float values, float min_val, float max_val);
+ * @brief constrains the torque based on soft Start
+ * @param torque[in, out] the torque to be constrained
+ */
+  void ConstrainTorque(float &torque) const;
 
   /*!
    * @brief constructor for soft Start
@@ -52,5 +41,30 @@ class SoftStart {
    * @param duration_ms how long for ramp to last in ms
    */
   SoftStart(float max_torque, float duration_ms);
+
+  /*!
+   * @brief Starts the soft start timer
+   */
+  static void InitializeTimer();
 };
+
+namespace TorqueLimiter {
+/*!
+ * @brief constrains a single value between min_val and max_val
+ * @param values[in]
+ * @param min_val minimum value allowed
+ * @param max_val maximum value allowed
+ * @return constrained value
+ */
+float Constrain(float values, float min_val, float max_val);
+
+/*!
+ * @brief constrains all values in values between min_val and max_val
+ * @param values[in, out] vector to be constrained
+ * @param min_val minimum value allowed in vector
+ * @param max_val maximum value allowed in vector
+ */
+void Constrain(std::vector<float> &values, float min_val, float max_val);
+
+}
 } // namespace kodlab

--- a/include/kodlab_mjbots_sdk/soft_start.h
+++ b/include/kodlab_mjbots_sdk/soft_start.h
@@ -30,14 +30,14 @@ class SoftStart {
   void ConstrainTorques(std::vector<float> &torques) const;
 
   /*!
- * @brief constrains the torque based on soft Start
+ * @brief constrains the torque based on soft start
  * @param torque[in, out] the torque to be constrained
  */
   void ConstrainTorque(float &torque) const;
 
   /*!
-   * @brief constructor for soft Start
-   * @param max_torque maximum torque allowed in robot
+   * @brief constructor for soft start
+   * @param max_torque maximum torque allowed in joint
    * @param duration_ms how long for ramp to last in ms
    */
   SoftStart(float max_torque, float duration_ms);
@@ -56,7 +56,7 @@ namespace TorqueLimiter {
  * @param max_val maximum value allowed
  * @return constrained value
  */
-float Constrain(float values, float min_val, float max_val);
+float Constrain(float value, float min_val, float max_val);
 
 /*!
  * @brief constrains all values in values between min_val and max_val

--- a/src/joint_base.cpp
+++ b/src/joint_base.cpp
@@ -20,10 +20,11 @@ JointBase::JointBase(std::string name,
                      float gear_ratio,
                      float max_torque,
                      float pos_min,
-                     float pos_max)
+                     float pos_max,
+                     float soft_start_duration_ms)
     : name_(name), direction_(direction), zero_offset_(zero_offset),
       max_torque_(max_torque), gear_ratio_(gear_ratio),
-      pos_limit_min_(pos_min), pos_limit_max_(pos_max)
+      pos_limit_min_(pos_min), pos_limit_max_(pos_max),soft_start_(max_torque, soft_start_duration_ms)
 {
     // Set to sign if not -1 or 1
     direction_ = (direction_ >= 0) - (direction_ < 0);
@@ -41,13 +42,13 @@ JointBase::JointBase(int direction,
                      float gear_ratio,
                      float max_torque,
                      float pos_min,
-                     float pos_max)
-    : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max) {}
+                     float pos_max,
+                     float soft_start_duration_ms)
+    : JointBase("", direction, zero_offset, gear_ratio, max_torque, pos_min, pos_max, soft_start_duration_ms) {}
 
 float JointBase::UpdateTorque(float joint_torque){
     // Clip max torque
-    joint_torque =  joint_torque >  max_torque_ ?  max_torque_ : joint_torque;
-    joint_torque =  joint_torque < -max_torque_ ? -max_torque_ : joint_torque;
+    soft_start_.ConstrainTorque(joint_torque);
 
     // Do soft stop if active 
     // Soft Stop: don't allow torque in the direction of the limits

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -44,10 +44,8 @@ std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Cop of torque_cmds
 }
 
 void kodlab::RobotBase::SetTorques(std::vector<float> torques) {
-  soft_start_.ConstrainTorques(torques, run_timer_.tac()/1000.0);
-  float torque_cmd;
   for (int joint_ind = 0; joint_ind < num_joints_; joint_ind++) {
-    torque_cmd = joints[joint_ind]->UpdateTorque(torques[joint_ind]);
+    joints[joint_ind]->UpdateTorque(torques[joint_ind]);
   }
 }
 

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -38,7 +38,7 @@ std::vector<std::shared_ptr<kodlab::JointBase>> kodlab::RobotBase::GetJoints(std
   return kodlab::RobotBase::GetJoints(joint_vect);
 }
 
-std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Cop of torque_cmds
+std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Copy of torque_cmds
   std::vector<float>torques(torque_cmd_.begin(), torque_cmd_.end());
   return torques;
 }

--- a/src/soft_start.cpp
+++ b/src/soft_start.cpp
@@ -14,12 +14,12 @@ void TorqueLimiter::Constrain(std::vector<float> &values,
                           float min_val,
                           float max_val) {
   for (auto &value : values) {
-    value = fmin(fmax(value, min_val), max_val);
+    value = std::min(std::max(value, min_val), max_val);
   }
 }
 
 float TorqueLimiter::Constrain(float values, float min_val, float max_val) {
-  return fmin(fmax(values, min_val), max_val);
+  return std::min(std::max(values, min_val), max_val);
 }
 
 void SoftStart::ConstrainTorques(std::vector<float> &torques) const {
@@ -44,11 +44,11 @@ void SoftStart::ConstrainTorque(float &torque) const {
       TorqueLimiter::Constrain(torque, -max_torque_, max_torque_);
     } else {
       float max_val = time_since_start_ms * slope_;
-      TorqueLimiter::Constrain(torque, -max_val, max_val);
+      torque = TorqueLimiter::Constrain(torque, -max_val, max_val);
     }
   } else{
     LOG_ERROR("Soft start not initialized, constraining torque to zero");
-    TorqueLimiter::Constrain(torque, -0, 0);
+    torque = 0;
   }
 }
 

--- a/src/soft_start.cpp
+++ b/src/soft_start.cpp
@@ -18,8 +18,8 @@ void TorqueLimiter::Constrain(std::vector<float> &values,
   }
 }
 
-float TorqueLimiter::Constrain(float values, float min_val, float max_val) {
-  return std::min(std::max(values, min_val), max_val);
+float TorqueLimiter::Constrain(float value, float min_val, float max_val) {
+  return std::min(std::max(value, min_val), max_val);
 }
 
 void SoftStart::ConstrainTorques(std::vector<float> &torques) const {

--- a/src/soft_start.cpp
+++ b/src/soft_start.cpp
@@ -6,10 +6,11 @@
 
 
 #include "kodlab_mjbots_sdk/soft_start.h"
+#include "kodlab_mjbots_sdk/log.h"
 
 namespace kodlab {
 
-void SoftStart::Constrain(std::vector<float> &values,
+void TorqueLimiter::Constrain(std::vector<float> &values,
                           float min_val,
                           float max_val) {
   for (auto &value : values) {
@@ -17,19 +18,38 @@ void SoftStart::Constrain(std::vector<float> &values,
   }
 }
 
-float SoftStart::Constrain(float values, float min_val, float max_val) {
+float TorqueLimiter::Constrain(float values, float min_val, float max_val) {
   return fmin(fmax(values, min_val), max_val);
 }
 
-void SoftStart::ConstrainTorques(std::vector<float> &torques,
-                                 float time_since_start_ms) {
-  if (time_since_start_ms > duration_ms_) {
-    Constrain(torques, -max_torque_, max_torque_);
-  } else {
-    float max_val = time_since_start_ms * slope_;
-    Constrain(torques, -max_val, max_val);
+void SoftStart::ConstrainTorques(std::vector<float> &torques) const {
+  if(timer_initialized_){
+    float time_since_start_ms = SoftStart::timer_.tac()/1000.0;
+    if (time_since_start_ms > duration_ms_) {
+      TorqueLimiter::Constrain(torques, -max_torque_, max_torque_);
+    } else {
+      float max_val = time_since_start_ms * slope_;
+      TorqueLimiter::Constrain(torques, -max_val, max_val);
+    }
+  }else{
+    LOG_ERROR("Soft start not initialized, constraining torque to zero");
+    TorqueLimiter::Constrain(torques, -0, 0);
   }
+}
 
+void SoftStart::ConstrainTorque(float &torque) const {
+  if(timer_initialized_) {
+    float time_since_start_ms = SoftStart::timer_.tac() / 1000.0;
+    if (time_since_start_ms > duration_ms_) {
+      TorqueLimiter::Constrain(torque, -max_torque_, max_torque_);
+    } else {
+      float max_val = time_since_start_ms * slope_;
+      TorqueLimiter::Constrain(torque, -max_val, max_val);
+    }
+  } else{
+    LOG_ERROR("Soft start not initialized, constraining torque to zero");
+    TorqueLimiter::Constrain(torque, -0, 0);
+  }
 }
 
 SoftStart::SoftStart(float max_torque, float duration_ms)
@@ -37,4 +57,11 @@ SoftStart::SoftStart(float max_torque, float duration_ms)
       duration_ms_(duration_ms),
       slope_(fabs(max_torque) / (fmax(duration_ms, 1.0))) {}
 
+bool SoftStart::timer_initialized_ = false;
+real_time_tools::Timer SoftStart::timer_;
+
+void SoftStart::InitializeTimer() {
+  timer_.tic();
+  timer_initialized_ = true;
+}
 } // kodlab


### PR DESCRIPTION
This is a breaking change for anyone using moteus level pd loop, but moves soft start from robot level to joint level. Moves a timer into the soft start. Also makes it harder to bypass soft start.