### PR TITLE
Joystick Controller Communication port

### DIFF
--- a/python_scripts/joystick/joystick_abstract.py
+++ b/python_scripts/joystick/joystick_abstract.py
@@ -1,0 +1,212 @@
+"""Provide an abstract class for interfacing with joystick hardware and an 
+example implementation.
+
+This file provides an abstract class with methods to interpret serial input 
+from joystick devices. A sample child class implementation is also provided as
+a guide for implementing custom joysticks.
+
+This code was largely copied from [1]
+
+Citations:
+    [1] K. Kruempelstaedter, kevkruemp/donkeypart_logitech_controller, 2018. 
+    [Online]. Available: https://github.com/kevkruemp/donkeypart_logitech_controller
+
+Maintainer:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+
+License:
+    BSD 3-Clause License
+
+Copyright:
+    Copyright 2022, The Trustees of the University of Pennsylvania. All Rights
+    Reserved.
+"""
+
+import os
+import array
+import time
+import struct
+from fcntl import ioctl
+
+
+INT16_MAX = 32767
+
+class Joystick(object):
+    """Abstract class defining different joystick hardware.
+    
+    This abstract class contains functions to interpret the serial input from
+    joystick devices. Based on the mapping that will be setup by the inherited 
+    class the joystick values can be mapped properly. The functions implemented 
+    in the class can be used for joystick device.
+    """
+
+    def __init__(self, device_id='/dev/input/js0'):
+        self.axis_states = {} # Contains the mapping of the axis for joystick
+        self.button_states = {} # Contains the mapping of the buttons for joystick
+        self.axis_list = [] 
+        self.button_map = []
+        self.jsdev = None # Variable to store the open device port.
+        self.set_device_id(device_id) 
+        self.axis_normalization = INT16_MAX # Sets the joystick ADC range 
+ 
+    def device_init(self):
+        """Setup connection to device and mapping of buttons.
+        
+        Initialization method that opens the device port, reads the 
+        number of axes and buttons, and maps them. Contains a single call to
+        setup connection to device and mapping of buttons.
+
+        Note:
+            This init needs to called after the axis_names and button_names are 
+            defined.
+        """
+
+        try:
+            from fcntl import ioctl
+        except ModuleNotFoundError:
+            self.num_axes = 0
+            self.num_buttons = 0
+            print("no support for fnctl module. joystick not enabled.")
+            return
+
+        if not os.path.exists(self.device_id):
+            print("Joystick device", self.device_id, "is missing")
+            return
+
+        # Open the joystick device.
+        print('Opening %s...' % self.device_id)
+        self.jsdev = open(self.device_id, 'rb')
+
+        # Get the device name.
+        buf = array.array('B', [0] * 64)
+        ioctl(self.jsdev, 0x80006a13 + (0x10000 * len(buf)), buf)  # JSIOCGNAME(len)
+        self.js_name = buf.tobytes().decode('utf-8')
+        print('Device name: %s' % self.js_name)
+
+        # Get number of axes.
+        buf = array.array('B', [0])
+        ioctl(self.jsdev, 0x80016a11, buf)  # JSIOCGAXES
+        self.num_axes = buf[0]
+
+        # Get number of buttons.
+        buf = array.array('B', [0])
+        ioctl(self.jsdev, 0x80016a12, buf)  # JSIOCGBUTTONS
+        self.num_buttons = buf[0]
+
+        # Get the axis map.
+        buf = array.array('B', [0] * 0x40)
+        ioctl(self.jsdev, 0x80406a32, buf)  # JSIOCGAXMAP
+
+        for axis in buf[:self.num_axes]:
+            axis_name = self.axis_names.get(axis, 'unknown(0x%02x)' % axis)
+            self.axis_list.append(axis_name)
+            self.axis_states[axis_name] = 0.0
+
+        # Get the button map.
+        buf = array.array('H', [0] * 200)
+        ioctl(self.jsdev, 0x80406a34, buf)  # JSIOCGBTNMAP
+
+        for btn in buf[:self.num_buttons]:
+            btn_name = self.button_names.get(btn, 'unknown(0x%03x)' % btn)
+            self.button_map.append(btn_name)
+            self.button_states[btn_name] = 0
+            # print('btn', '0x%03x' % btn, 'name', btn_name)
+            # TODO: Set a input variable to get
+
+        return True
+
+    def show_map(self):
+        """Print joystick axis and button mappings.
+
+        List the buttons and axis found on this joystick.
+        """
+        print('%d axes found: %s' % (self.num_axes, ', '.join(self.axis_list)))
+        print('%d buttons found: %s' % (self.num_buttons, ', '.join(self.button_map)))
+
+    def set_device_id(self, device_id):
+        """Sets device id
+
+        Function allowing us to set the device_id.
+        """
+        self.device_id = device_id
+
+    def poll(self):
+        """Read the joystick port
+
+        Query the state of the joystick, returns button which was pressed,
+        if any, and axis which was moved, if any. button_state will be None,
+        1, or 0 if no changes, pressed, or released. axis_val will be a 
+        float from -1 to +1. button and axis will be the string label
+        determined by the axis map in init.
+
+        Returns:
+            The button name, button value, axis name, axis value. These are 
+            returned as a seperate value. 
+        """
+
+        button = None
+        button_state = None
+        axis = None
+        axis_val = None
+
+        if self.jsdev is None:
+            return button, button_state, axis, axis_val
+
+        # Main event loop
+        evbuf = self.jsdev.read(8)
+
+        if evbuf:
+            tval, value, typev, number = struct.unpack('IhBB', evbuf)
+
+            if typev & 0x80:
+                # ignore initialization event
+                return button, button_state, axis, axis_val
+
+            if typev & 0x01:
+                button = self.button_map[number]
+                # print(tval, value, typev, number, button, 'pressed')
+                if button:
+                    self.button_states[button] = value
+                    button_state = value
+
+            if typev & 0x02:
+                axis = self.axis_list[number]
+                if axis:
+                    fvalue = value / self.axis_normalization
+                    self.axis_states[axis] = fvalue
+                    axis_val = fvalue
+
+        return button, button_state, axis, axis_val
+
+class JoystickCreator(Joystick):
+    """Example joystick implementation class
+    
+    A sample class that user-defined joysticks should be modelled off of. The 
+    axis button names, which are specific to the joystick being used, are 
+    loaded here.
+
+    Anyone using this class as an example should populate the 
+    ``self.axis_names`` and ``self.button_names`` dictionaries with their 
+    desired mappings.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(JoystickCreator, self).__init__(*args, **kwargs)
+
+        self.axis_names = {}
+        self.button_names = {}
+
+    def run(self):
+        while True:
+            button, button_state, axis, axis_val = self.poll()
+            print(button)
+            if axis is not None or button is not None:
+                if button is None:
+                    button = "0"
+                    button_state = 0
+                if axis is None:
+                    axis = "0"
+                    axis_val = 0
+                message_data = (button, button_state, axis, axis_val)
+                print(message_data)
+

--- a/python_scripts/joystick/joystick_controller.py
+++ b/python_scripts/joystick/joystick_controller.py
@@ -1,0 +1,95 @@
+"""Provides the ``JoystickController`` aggregate joystick hardware class.
+
+TODO:
+    Need to load a YAML file so that many arguments are not required 
+    to be passed when we start the file.
+
+Maintainer:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+
+Author:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+    Ethan J. Musser (emusser@seas.upenn.edu)
+
+License:
+    BSD 3-Clause License
+
+Copyright:
+    Copyright 2022, The Trustees of the University of Pennsylvania. All Rights
+    Reserved.
+"""
+
+from .joystick_logitech import LogitechJoystick
+from .joystick_xbox import XboxJoystick
+from lcm_types.ControllerCommand import ControllerCommand
+
+
+class JoystickController(object):
+    """Class accepting multiple joysticks and selecting one based on user 
+    specification.
+
+    This class combines the hardware controllers for the Logitech and X-Box 360 
+    joysticks. The proper controller is loaded based on construction 
+    parameters.
+    """
+
+    def __init__(self, linear_scaling=[1.0, 1.0, 1.0],
+                 angular_scaling=[1.0, 1.0, 1.0],
+                 joystick_type='logitech', device_id='/dev/input/js0'):
+        self.linear_scaling = linear_scaling
+        self.angular_scaling = angular_scaling
+        self.message = ControllerCommand()
+        self.message_map = {}
+        self.device_id = device_id
+        self.joystick_select(joystick_type)
+
+
+    def joystick_select(self, joystick_type):
+        """Select a joystick given a joystick name."""
+
+        self.joystick_type = joystick_type
+        if joystick_type == "logitech":
+            self.c = LogitechJoystick(device_id=self.device_id)
+            self.message_map['linear_x'] = self.c.axis_names.get(0x01)
+            self.message_map['linear_y'] = self.c.axis_names.get(0x00)
+            self.message_map['linear_z'] = self.c.axis_names.get(0x11)
+            self.message_map['angular_x'] = self.c.axis_names.get(0x10)
+            self.message_map['angular_y'] = self.c.axis_names.get(0x04)
+            self.message_map['angular_z'] = self.c.axis_names.get(0x03)
+        elif joystick_type == "xbox":
+            self.c = XboxJoystick(device_id=self.device_id)
+            self.message_map['linear_x'] = self.c.axis_names.get(0x01)
+            self.message_map['linear_y'] = self.c.axis_names.get(0x00)
+            self.message_map['linear_z'] = self.c.axis_names.get(0x11)
+            self.message_map['angular_x'] = self.c.axis_names.get(0x10)
+            self.message_map['angular_y'] = self.c.axis_names.get(0x04)
+            self.message_map['angular_z'] = self.c.axis_names.get(0x03)
+        else:
+            print(f'[WARN] Invalid joystick selected, `{joystick_type}` is not'
+                  f'a valid joystick.')
+
+    def poll(self):
+        """Wrapper Function for poll.
+        
+        The Abstract class poll function is called, These values are scaled 
+        based on the factor we require. The scaling is set by the user. 
+        
+        TODO: 
+            Add a YAML file to load the parameters.
+        """
+
+        button, button_state, axis, axis_val = self.c.poll()
+        
+        if axis == self.message_map['linear_x']:
+            self.message.linear[0] = axis_val * self.linear_scaling[0]
+        elif axis == self.message_map['linear_y']:
+            self.message.linear[1] = axis_val * self.linear_scaling[1]
+        elif axis == self.message_map['linear_z']:
+            self.message.linear[2] = axis_val * self.linear_scaling[2]
+        elif axis == self.message_map['angular_x']:
+            self.message.angular[0] = axis_val * self.angular_scaling[0]
+        elif axis == self.message_map['angular_y']:
+            self.message.angular[1] = axis_val * self.angular_scaling[1]
+        elif axis == self.message_map['angular_z']:
+            self.message.angular[2] = axis_val * self.angular_scaling[2]   
+

--- a/python_scripts/joystick/joystick_logitech.py
+++ b/python_scripts/joystick/joystick_logitech.py
@@ -1,0 +1,98 @@
+"""Contains class definition for Logitech F710 joystick.
+
+This Files contains a specific class that contains mapping for Logitech F710.
+
+TODO: 
+    Add joystick model number(s).
+
+Maintainer:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+
+License:
+    BSD 3-Clause License
+
+Copyright:
+    Copyright 2022, The Trustees of the University of Pennsylvania. All Rights
+    Reserved.
+"""
+
+from .joystick_abstract import Joystick
+
+class LogitechJoystick(Joystick):
+    """Joystick implementation for a Logitech F710 gamepad"""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize joystick mappings and hardware interface."""
+
+        print("Joystick mapping loaded for Logitech joystick.")
+        super(LogitechJoystick, self).__init__(*args, **kwargs)
+        
+        # Axis and button names are assigned based on the mapping from the logitech
+        self.axis_names = {
+            0x00: 'left_stick_horz',
+            0x01: 'left_stick_vert',
+            0x03: 'right_stick_horz',
+            0x04: 'right_stick_vert',
+
+            0x02: 'L2_pressure',
+            0x05: 'R2_pressure',
+
+            0x10: 'dpad_leftright', # 1 is right, -1 is left
+            0x11: 'dpad_up_down', # 1 is down, -1 is up
+
+        }
+
+        self.button_names = {
+            0x13a: 'back',  
+            0x13b: 'start',  
+            0x13c: 'logitech',  
+
+            0x130: 'A',
+            0x131: 'B',
+            0x133: 'X',
+            0x134: 'Y',
+
+            0x136: 'LB',
+            0x137: 'RB',
+
+            0x13d: 'left_stick_press',
+            0x13e: 'right_stick_press',
+        }
+
+        super(LogitechJoystick, self).device_init()
+
+    def run_loop(self):
+        """Running the read operation in an infanite loop
+        
+        This function contains an infinite loop to run the polling and retrieving data.
+        Can be used for debugging, but for real usuage advisable to use the run_once function
+        """
+
+        while True:
+            button, button_state, axis, axis_val = self.poll()
+            if axis is not None or button is not None:
+                if button is None:
+                    button = "0"
+                    button_state = 0
+                if axis is None:
+                    axis = "0"
+                    axis_val = 0
+                message_data = (button, button_state, axis, axis_val)
+                print(message_data)
+
+    def run_once(self):
+        """Running the read operation once
+
+        This function samples retrieves the pool only once. It works like a trigger.
+        """
+
+        button, button_state, axis, axis_val = self.poll()
+        if axis is not None or button is not None:
+            if button is None:
+                button = "0"
+                button_state = 0
+            if axis is None:
+                axis = "0"
+                axis_val = 0
+            message_data = (button, button_state, axis, axis_val)
+            print(message_data)

--- a/python_scripts/joystick/joystick_xbox.py
+++ b/python_scripts/joystick/joystick_xbox.py
@@ -1,0 +1,100 @@
+"""Contains class definition for Xbox 360 joystick.
+
+This Files contains a specific class inherited from JoystickAbstract that
+contains mapping for Xbox 360.
+
+TODO:
+    Add joystick model number.
+
+Maintainer:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+
+License:
+    BSD 3-Clause License
+
+Copyright:
+    Copyright 2022, The Trustees of the University of Pennsylvania. All Rights
+    Reserved.
+"""
+
+from .joystick_abstract import Joystick
+
+class XboxJoystick(Joystick):
+    """Joystick implementation for an X-Box 360 gamepad"""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize joystick mappings and hardware interface."""
+
+        print("Joystick mapping loaded for X-Box 360 joystick.")
+        super(XboxJoystick, self).__init__(*args, **kwargs)
+    
+        # Axis and button names are assigned based on the mapping from the logitech
+        self.axis_names = {
+            0x00: 'left_stick_horz',
+            0x01: 'left_stick_vert',
+            0x03: 'right_stick_horz',
+            0x04: 'right_stick_vert',
+
+            0x0a: 'LT_Pressure',
+            0x09: 'RT_Pressure',
+
+            0x10: 'dpad_leftright', # 1 is right, -1 is left
+            0x11: 'dpad_up_down', # 1 is down, -1 is up
+
+        }
+
+        self.button_names = {
+            0x13a: 'back',  # 8 314
+            0x13b: 'start',  # 9 315
+            0x13c: 'xbox',  # a  316
+
+            0x130: 'A',
+            0x131: 'B',
+            0x133: 'X',
+            0x134: 'Y',
+
+            0x136: 'LB',
+
+            0x137: 'RB',
+
+            0x13d: 'left_stick_press',
+            0x13e: 'right_stick_press',
+        }
+
+        super(XboxJoystick, self).device_init()
+
+    def run_loop(self):
+        """Running the read operation in an infanite loop
+        
+        This function contains an infinite loop to run the polling and retrieving data.
+        Can be used for debugging, but for real usuage advisable to use the run_once function
+        """
+
+        while True:
+            button, button_state, axis, axis_val = self.poll()
+            if axis is not None or button is not None:
+                if button is None:
+                    button = "0"
+                    button_state = 0
+                if axis is None:
+                    axis = "0"
+                    axis_val = 0
+                message_data = (button, button_state, axis, axis_val)
+                print(message_data)
+
+    def run_once(self):
+        """Running the read operation once
+
+        This function samples retrieves the pool only once. It works like a trigger.
+        """
+
+        button, button_state, axis, axis_val = self.poll()
+        if axis is not None or button is not None:
+            if button is None:
+                button = "0"
+                button_state = 0
+            if axis is None:
+                axis = "0"
+                axis_val = 0
+            message_data = (button, button_state, axis, axis_val)
+            print(message_data)

--- a/python_scripts/joystick_lcm.py
+++ b/python_scripts/joystick_lcm.py
@@ -1,0 +1,127 @@
+"""Script that polls a Logitech joystick and repeatedly transmits a 
+corresponding controller command via LCM
+
+
+TODO:
+    Load a YAML file so that fewer arguments are required when running the
+    file.
+    Change the input based on the button pressed.
+
+Maintainer:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+
+Author:
+    Chandravaran Kunjeti (kunjeti@seas.upenn.edu)
+    Ethan J. Musser (emusser@seas.upenn.edu)
+
+License:
+    BSD 3-Clause License
+
+Copyright:
+    Copyright 2022, The Trustees of the University of Pennsylvania. All Rights
+    Reserved.
+"""
+
+from joystick.joystick_controller import JoystickController
+import lcm
+from lcm_types.ControllerCommand import ControllerCommand 
+import warnings
+import argparse
+
+# Ignore deprecation warnings from ``lcm`` dependencies
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+# Constants
+DEFAULT_LCM_CHANNEL = "controller_input"  # Input controller message channel 
+DEFAULT_DEVICE_ID = "/dev/input/js0"  # Default device ID for joystick device
+DEFAULT_JOYSTICK_TYPE = "logitech"  # Default joystick type
+
+
+def parse_args():
+    """Parse input arguments"""
+    parser = argparse.ArgumentParser(
+        description='publish mode input messages via LCM.')
+    parser.add_argument('channel', type=str, default=DEFAULT_LCM_CHANNEL,
+                        help='LCM channel name to publish controller message on')
+    parser.add_argument('device_id', type=str, default=DEFAULT_DEVICE_ID,
+                        help='Joystick hardware device ID')
+    parser.add_argument('-j', '--joystick-type', type=str,
+                        default=DEFAULT_JOYSTICK_TYPE,
+                        help=(f'Joystick type (`xbox` or `logitech`, default '
+                              f'`{DEFAULT_JOYSTICK_TYPE}`)'))
+    parser.add_argument('-lx', '--linear-scale-x', type=float, default=1.0,
+                        help='Linear x-velocity scaling (default 1.0)')
+    parser.add_argument('-ly', '--linear-scale-y', type=float, default=1.0,
+                        help='Linear y-velocity scaling (default 1.0)')
+    parser.add_argument('-lz', '--linear-scale-z', type=float, default=1.0,
+                        help='Linear z-velocity scaling (default 1.0)')
+    parser.add_argument('-ax', '--angular-scale-x', type=float, default=1.0,
+                        help='Angular x-velocity scaling (default 1.0)')
+    parser.add_argument('-ay', '--angular-scale-y', type=float, default=1.0,
+                        help='Angular y-velocity scaling (default 1.0)')
+    parser.add_argument('-az', '--angular-scale-z', type=float, default=1.0,
+                        help='Angular z-velocity scaling (default 1.0)')
+    args = parser.parse_args()
+    return args
+
+
+def publish_command(message, print_msg="", lcm_ch=DEFAULT_LCM_CHANNEL):
+    """Publish an LCM ``ControllerCommand`` message on channel ``ch``, printing 
+    ``print_msg`` to console, if provided."""
+
+    # Publish Message
+    lc = lcm.LCM()
+    lc.publish(lcm_ch, message.encode())
+    if print_msg:
+        print(print_msg)
+
+
+def header_str(hardware_id, lcm_channel):
+    return '''
++--------------------------------------------------------------------+
+| Polling for input from hardware device:  {:25s} |
+| Publishing to channel:  {:42s} |
+| Exit with Ctrl-C.                                                  |
++--------------------------------------------------------------------+
+    '''.format(hardware_id, lcm_channel)
+
+
+def main():
+    # Parse input
+    args = parse_args()
+    device_id = args.device_id
+    channel = args.channel
+
+    # Initialize joystick
+    p = JoystickController(
+        device_id=device_id,
+        joystick_type=args.joystick_type,
+        linear_scaling=[args.linear_scale_x,
+                        args.linear_scale_y, args.linear_scale_z],
+        angular_scaling=[args.angular_scale_x,
+                         args.angular_scale_y, args.angular_scale_z]
+    )
+
+    # Print header
+    print(header_str(device_id, channel))
+
+    # Loop
+    try:
+        while True:
+            
+            try:
+                p.poll()
+                publish_command(p.message, lcm_ch=channel)
+            except ValueError:
+                publish_command(ControllerCommand(), lcm_ch=channel)
+    except KeyboardInterrupt:
+        print('Keyboard interrupt.  Killing Robot and exiting.')
+        for _ in range(5):  # ensure KILL message is received
+            publish_command(ControllerCommand(), lcm_ch=channel)
+
+
+if __name__ == '__main__':
+    main()
+
+
+


### PR DESCRIPTION
Work done by @chandravaran in a different repo with very minor edits (comments and name changes).

Adding joystick controls Python scripts. 
Added features:
- Configurable controllers, `JoystickAbstract`
- Logitech and Xbox controller example classes
- Example script for sending LCM kinematic twist command [x_dot, omega]

Issues:
- Some of the maps seem backward or redundant in how they are defined and used. We may want to have human-readable names that get mapped to the hex addresses instead of the reverse. Or at least maybe some master gamepad input list e.g. left-stick,  south-button (instead of "A" or "X"), assuming some minimal button set, and if it is missing a mapping function that replaces it. Overgeneralizing may be a problem here so mostly we would just want XBox, Logitech, Playstation, Generic or something.

Todo:
- [ ] Add the controller_command.lcm struct
- [ ] Fix the mappings to be more useful to a general audience
- [ ] Perhaps draw up an example where more buttons are used e.g. expanding the twist command to be able to jump with "A" button
- [ ] Make an example script that runs with a `BehaviorIO`in a simple robot.
- [ ] YAML configuration of the controllers