### PR TITLE
Fix base classes, consts and virtual destructors

### DIFF
--- a/include/kodlab_mjbots_sdk/abstract_realtime_object.h
+++ b/include/kodlab_mjbots_sdk/abstract_realtime_object.h
@@ -22,6 +22,12 @@ class AbstractRealtimeObject {
   AbstractRealtimeObject(int realtime_priority, int cpu);
 
   /*!
+   * @brief Destroy the AbstractRealtimeObject. Virtual destructor for proper
+   * derived pointer destruction.
+   */
+  virtual ~AbstractRealtimeObject(){};
+
+  /*!
    * @brief joins the realtime thread
    */
   void Join();

--- a/include/kodlab_mjbots_sdk/joint_base.h
+++ b/include/kodlab_mjbots_sdk/joint_base.h
@@ -75,6 +75,12 @@ class JointBase {
         );
 
         /**
+         * @brief Destroy the JointBase object, virtual to ensure proper 
+         * destruction of derived classes
+         */
+        virtual ~JointBase(){}
+
+        /**
          * @brief Update position and velocity using all the servo params (gear ratio, offset, direction)
          * 
          * @param servo_pos raw servo position

--- a/include/kodlab_mjbots_sdk/joint_moteus.h
+++ b/include/kodlab_mjbots_sdk/joint_moteus.h
@@ -132,6 +132,12 @@ class JointMoteus: public JointBase
               moteus_kd_(config.moteus_kd){}
         
         /**
+         * @brief Destroy the JointMoteus object, virtual to ensure proper 
+         * destruction of derived classes
+         */
+        virtual ~JointMoteus(){}
+
+        /**
          * @brief Update the joint of the moteus. Converts rot/s to rad/s and saves mode
          * 
          * @param reply_pos position reported by moteus [rot]

--- a/include/kodlab_mjbots_sdk/mjbots_control_loop.h
+++ b/include/kodlab_mjbots_sdk/mjbots_control_loop.h
@@ -78,7 +78,12 @@ class MjbotsControlLoop : public AbstractRealtimeObject {
    * \overload 
    */
   MjbotsControlLoop(std::shared_ptr<RobotClass>robot_in, const ControlLoopOptions &options);
-
+  /*!
+   * @brief Destroy the MjbotsControlLoop object. Virtual destructor for proper
+   * derived pointer destruction.
+   */
+  virtual ~MjbotsControlLoop(){}
+  
  protected:
 
   /*!

--- a/include/kodlab_mjbots_sdk/robot_base.h
+++ b/include/kodlab_mjbots_sdk/robot_base.h
@@ -98,16 +98,17 @@ namespace kodlab
         }
 
         /*!
-         * @brief accessor for joint positions, takes into account direction and offset
+         * @brief accessor for joint positions, takes into account direction 
+         * and offset
          * @return the joint positions
          */
-        std::vector<float> GetJointPositions();
+        std::vector<float> GetJointPositions() const;
 
         /*!
          * @brief accessor for joint velocities, takes into account direction
          * @return the joint velocities
          */
-        std::vector<float> GetJointVelocities();
+        std::vector<float> GetJointVelocities() const;
 
         /*!
          * @brief setter for torque command
@@ -119,19 +120,20 @@ namespace kodlab
          * @brief accessor for the torque md, takes into account direction
          * @return the torque cmd
          */
-        std::vector<float> GetJointTorqueCmd();
+        std::vector<float> GetJointTorqueCmd() const;
 
         /*!
         * @brief accessor for the IMU data of the robot
         * @return const reference to the IMU data object for the robot
         */
-        const ::kodlab::IMUData<float>& GetIMUData(){return *imu_data_;}
+        const ::kodlab::IMUData<float>& GetIMUData() const {return *imu_data_;}
 
         /*!
         * @brief accessor for the IMU data of the robot
         * @return const IMU data shared pointer for the robot
         */
-        const std::shared_ptr<::kodlab::IMUData<float>> GetIMUDataSharedPtr(){return imu_data_;}
+        const std::shared_ptr<::kodlab::IMUData<float>> 
+              GetIMUDataSharedPtr() const {return imu_data_;}
 
         /*!
         * @brief Setter for the robot's IMU data pointer. Releases the previously owned IMU data object
@@ -175,7 +177,8 @@ namespace kodlab
          * @param name the name of the joint
          * @return the index of the joint
          */
-        int joint_index_by_name_fatal(const std::string& name){return joint_name_to_index_.at(name);};
+        int joint_index_by_name_fatal(const std::string& name) const {
+              return joint_name_to_index_.at(name);};
 
     protected:
         std::vector<std::reference_wrapper<const float>> positions_;  /// Vector of the motor positions (references to the members of joints_)

--- a/src/robot_base.cpp
+++ b/src/robot_base.cpp
@@ -9,12 +9,14 @@
  */
 #include "kodlab_mjbots_sdk/robot_base.h"
 
-std::vector<float> kodlab::RobotBase::GetJointPositions() { //Copy of positions
+std::vector<float> kodlab::RobotBase::GetJointPositions() const{
+  // Return a copy of positions
   std::vector<float>pos(positions_.begin(), positions_.end());
   return pos;
 }
 
-std::vector<float> kodlab::RobotBase::GetJointVelocities() { //Copy of velocities
+std::vector<float> kodlab::RobotBase::GetJointVelocities() const {
+  // Return a copy of velocities
   std::vector<float>vel(velocities_.begin(), velocities_.end());
   return vel;
 }
@@ -38,7 +40,8 @@ std::vector<std::shared_ptr<kodlab::JointBase>> kodlab::RobotBase::GetJoints(std
   return kodlab::RobotBase::GetJoints(joint_vect);
 }
 
-std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() { //Copy of torque_cmds
+std::vector<float> kodlab::RobotBase::GetJointTorqueCmd() const {
+  // Return a copy of torque_cmds
   std::vector<float>torques(torque_cmd_.begin(), torque_cmd_.end());
   return torques;
 }


### PR DESCRIPTION
Fixes missing virtual destructors and the const correctness of many of the robot base member functions. 
A good opportunity to do more minor clean up on the base classes, if anything comes to mind.

This may require some const-correctness fixes to existing code.